### PR TITLE
Correct “C/C++” → “CoffeeScript” in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CoffeeScript language support in Atom
 
-Adds syntax highlighting and snippets to C/C++ files in Atom.
+Adds syntax highlighting and snippets to CoffeeScript files in Atom.
 
 Originally [converted](http://atom.io/docs/latest/converting-a-text-mate-bundle)
 from the [CoffeeScript TextMate bundle](https://github.com/jashkenas/coffee-script-tmbundle).


### PR DESCRIPTION
I’m guessing it was just copied-and-pasted and not changed. I don’t see any features for C or C++ in this project.
