### PR TITLE
Feature regexp syntax

### DIFF
--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -103,14 +103,14 @@
   }
   {
     'begin': '/{3}'
-    'end': '/{3}[imgy]{0,4}'
+    'end': '(/{3})[imgy]{0,4}'
     'name': 'string.regexp.coffee'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.js'
 
     'endCaptures':
-      '0':
+      '1':
         'name': 'punctuation.definition.string.begin.js'
 
     'patterns': [
@@ -121,8 +121,8 @@
 
   }
   {
-    'begin': '(?<!\\d|\\d\\s)/{1}(?=[^\n]+(?<!\\\\)/(?!\\s|\\d))',
-    'end': '/{1}[imgy]{0,4}',
+    'begin': '(?<!\\d|\\d\\s)/{1}(?=[^\n]+(?<!\\\\)/(?!\\s|\\d))'
+    'end': '(/{1})[imgy]{0,4}'
     'name': 'string.regexp.coffee'
     'patterns': [
       {
@@ -134,7 +134,7 @@
         'name': 'punctuation.definition.string.begin.js'
 
     'endCaptures':
-      '0':
+      '1':
         'name': 'punctuation.definition.string.begin.js'
 
   }


### PR DESCRIPTION
This PR reply initially to atom/language-coffee-script#8

The additions includes better support for inline regexes. Note that all divisions/regexes expressions have been tested against the CoffeeScript compiler so it should never highlight inappropriately divisions as regexes and vice versa.
For inner inlined regexes I reused the `source.js.regexp` grammar, but for the heregexp syntax I had to modify it a bit and include it in the CoffeeScript grammar to reuse the interpolated coffee rule.

Below a render of my sample file using the default Solarized dark theme:  
![Coffee Regexes Sample](http://i.imgur.com/8s7D9Dp.png?1)
