### PR TITLE
Highlight reserved words

### DIFF
--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -143,7 +143,7 @@
     'name': 'keyword.operator.coffee'
   }
   {
-    'match': '(?x)\\b(?<![\\.\\$])(case|default|function|var|void|with|const|let|enum|export|import|native|__hasProp|__extends|__slice|__bind|__indexOf|implements|interface|package|private|protected|public|static|yield)(?!\\s*:)\\b'
+    'match': '\\b(?<![\\.\\$])(case|default|function|var|void|with|const|let|enum|export|import|native|__hasProp|__extends|__slice|__bind|__indexOf|implements|interface|package|private|protected|public|static|yield)(?!\\s*:)\\b'
     'name': 'keyword.reserved.coffee'
   }
   {


### PR DESCRIPTION
so that we don't mistakenly use these words.
