### PR TITLE
Enhance require snippet

### DIFF
--- a/snippets/language-coffee-script.cson
+++ b/snippets/language-coffee-script.cson
@@ -55,7 +55,7 @@
     'body': 'console.error $0'
   'require':
     'prefix': 'req'
-    'body': '${1:sys} = require "${2:sys}"$3'
+    'body': '${1:sys} $3= require "${2:${1:sys}}"$4'
   'Describe block':
     'prefix': 'de',
     'body': 'describe "${1:description}", ->\n  ${2:body}'


### PR DESCRIPTION
I usually require modules into a variable with the same name as a module - guess it's not only me. So having two cursors and typing variable's and module's names simultaneously seems to make sense.

Second tab stop is for situations where names doesn't match. Then it's easy to make changes to module name, like

``` coffee-script
# req \t cson \t -> -safe
cson = require "cson-safe"
```

or

``` coffee-script
# req \t cson \t <- ./models/
User = require "./models/User"
```

Third stop is for pedants like me, who can't stand unaligned equal signs. Just type your spaces there.

Fourth is obviously at the end.

I'd be really happy if you merge this small contribution. Thanks for your great work.
