### PR TITLE
'class' isn't highlighted at the end of a word

### DIFF
--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -257,7 +257,7 @@
         'name': 'keyword.control.inheritance.coffee'
       '3':
         'name': 'entity.other.inherited-class.coffee'
-    'match': '(?:\s+|^)(class)\\s+(extends)\\s+(@?[a-zA-Z\\$\\._][\\w\\.]*)'
+    'match': '(?:\\s|^)(class)\\s+(extends)\\s+(@?[a-zA-Z\\$\\._][\\w\\.]*)'
     'name': 'meta.class.coffee'
   }
   {


### PR DESCRIPTION
Without this, the character string `class` is highlighted when appearing at the end of another word. For example:

![screen shot 2014-07-14 at 14 09 32](https://cloud.githubusercontent.com/assets/1965587/3571008/1f3fc628-0b58-11e4-93e2-a61aef1d08c3.png)

Where the correct behaviour would be only the final line being highlighted.
