### PR TITLE
Removing the 'documenting' capture assignment fixes #19

### DIFF
--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -220,8 +220,6 @@
     'captures':
       '1':
         'name': 'entity.name.function.coffee'
-      '2':
-        'name': 'entity.name.function.coffee'
       '3':
         'name': 'variable.parameter.function.coffee'
       '4':


### PR DESCRIPTION
Some grammers define capture assignments with as sole purpose to document the regular expression. This causes the embedded assignment of the entity.name.function scope to the last letter of a class method name.

After fixing the grammar, the tokens look like this for the same example:
![tokens after fix](https://cloud.githubusercontent.com/assets/151054/3806230/2adbd38c-1c47-11e4-94e5-7620df8f7a8c.png)
