### PR TITLE
Tokenize 'this' as a keyword

### DIFF
--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -146,7 +146,7 @@
     'name': 'keyword.operator.coffee'
   }
   {
-    'match': '\\b(?<![\\.\\$])(case|default|function|var|void|with|const|let|enum|export|import|native|__hasProp|__extends|__slice|__bind|__indexOf|implements|interface|package|private|protected|public|static|this|yield)(?!\\s*:)\\b'
+    'match': '\\b(?<![\\.\\$])(case|default|function|var|void|with|const|let|enum|export|import|native|__hasProp|__extends|__slice|__bind|__indexOf|implements|interface|package|private|protected|public|static|yield)(?!\\s*:)\\b'
     'name': 'keyword.reserved.coffee'
   }
   {
@@ -246,6 +246,10 @@
   {
     'match': '\\b(?<!\\.)extends(?!\\s*[:=])\\b'
     'name': 'variable.language.coffee'
+  }
+  {
+    'match': '\\b(?<!\\.)this(?!\\s*[:=])\\b'
+    'name': 'variable.language.this.coffee'
   }
   {
     'captures':

--- a/spec/coffee-script-spec.coffee
+++ b/spec/coffee-script-spec.coffee
@@ -90,7 +90,7 @@ describe "CoffeeScript grammar", ->
     expect(lines[1][1]).toEqual value: '@foo', scopes: ["source.coffee", "comment.block.coffee", "storage.type.annotation.coffee"]
     expect(lines[2][0]).toEqual value: '@bar', scopes: ["source.coffee", "comment.block.coffee", "storage.type.annotation.coffee"]
 
-  it "tokenizes this as a keyword", ->
+  it "tokenizes this as a special variable", ->
     {tokens} = grammar.tokenizeLine("this")
 
-    expect(tokens[0]).toEqual value: "this", scopes: ["source.coffee", "keyword.reserved.coffee"]
+    expect(tokens[0]).toEqual value: "this", scopes: ["source.coffee", "variable.language.this.coffee"]


### PR DESCRIPTION
Per the specification, `this` is a JavaScript keyword that is forbidden from being used as a variable or property name. So we should tokenize it as a keyword and not a variable.

See: http://coffeescript.org/documentation/docs/lexer.html#section-69

Fixes #36
