### PR TITLE
Disable auto-indent on paste

### DIFF
--- a/scoped-properties/language-coffee-script.cson
+++ b/scoped-properties/language-coffee-script.cson
@@ -3,6 +3,7 @@
     'commentStart': '# '
 '.source.coffee':
   'editor':
+    'autoIndentOnPaste': false
     'increaseIndentPattern': '(?x)
       ^\\s*
       (


### PR DESCRIPTION
Auto-indent on paste isn't useful here since coffee-script is whitespace-sensitive.
