### PR TITLE
Color function calls

### DIFF
--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -228,6 +228,10 @@
     'name': 'meta.function.coffee'
   }
   {
+    'match': '@?\\b\\w+(\\s+(?!(of|in|then|is|isnt|and|or))(?=(\\w+|\\->|\\-\\d|\\[|\\{|\"|\'))|(?=\\())'
+    'name': 'entity.name.function.coffee'
+  }
+  {
     'match': '[=-]>'
     'name': 'storage.type.function.coffee'
   }


### PR DESCRIPTION
When writing idiomatic CoffeeScript I find it very important to color function calls - otherwise they are just lost in a sea of code. This small regex adds it.