### PR TITLE
Switch To Single Quotes For `de` and `it` Snippets

### DIFF
--- a/snippets/language-coffee-script.cson
+++ b/snippets/language-coffee-script.cson
@@ -58,10 +58,10 @@
     'body': '${1:sys} $3= require \'${2:${1:sys}}\'$4'
   'Describe block':
     'prefix': 'de',
-    'body': 'describe "${1:description}", ->\n  ${2:body}'
+    'body': 'describe \'${1:description}\', ->\n  ${2:body}'
   'It block':
     'prefix': 'i',
-    'body': 'it "$1", ->\n  $2'
+    'body': 'it \'$1\', ->\n  $2'
   'Before each':
     'prefix': 'be',
     'body': 'beforeEach ->\n  $1'


### PR DESCRIPTION
This PR switches the `de` and `it` snippets to insert single quotes (`'`) instead of double quotes (`"`) by default.

The only argument against this I can think of is: 

> "I often use contractions (`doesn't`) in specs, and I don't want to have to escape the `'`"

The counter argument is that you're almost never doing string interpolation in specs, and it's not a huge cognitive burden to type `\` prior to a `'` in a contraction, or use `does not` in place of `doesn't`.