### PR TITLE
Fix regexp to detect backticks

### DIFF
--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -77,7 +77,8 @@
     'name': 'string.quoted.script.coffee'
     'patterns': [
       {
-        'include': 'source.js'
+        'match': '(x\h{2}|[0-2][0-7]{,2}|3[0-6][0-7]|37[0-7]?|[4-7][0-7]?|.)'
+        'name': 'constant.character.escape.coffee'
       }
     ]
   }

--- a/spec/coffee-script-spec.coffee
+++ b/spec/coffee-script-spec.coffee
@@ -223,3 +223,17 @@ describe "CoffeeScript grammar", ->
     expect(tokens[1]).toEqual value: ":", scopes: ["source.coffee", "keyword.operator.coffee"]
     expect(tokens[2]).toEqual value: ":", scopes: ["source.coffee", "keyword.operator.coffee"]
     expect(tokens[3]).toEqual value: "extends", scopes: ["source.coffee"]
+
+  it "tokenizes embedded JavaScript", ->
+    {tokens} = grammar.tokenizeLine("`;`")
+    expect(tokens[0]).toEqual value: "`", scopes: ["source.coffee", "string.quoted.script.coffee", "punctuation.definition.string.begin.coffee"]
+    expect(tokens[1]).toEqual value: ";", scopes: ["source.coffee", "string.quoted.script.coffee", "constant.character.escape.coffee"]
+    expect(tokens[2]).toEqual value: "`", scopes: ["source.coffee", "string.quoted.script.coffee", "punctuation.definition.string.end.coffee"]
+
+    lines = grammar.tokenizeLines """
+      `var a = 1;`
+      a = 2
+      """
+    expect(lines[0][0]).toEqual value: '`', scopes: ["source.coffee", "string.quoted.script.coffee", "punctuation.definition.string.begin.coffee"]
+    expect(lines[0][1]).toEqual value: 'v', scopes: ["source.coffee", "string.quoted.script.coffee", "constant.character.escape.coffee"]
+    expect(lines[1][0]).toEqual value: 'a ', scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee"]


### PR DESCRIPTION
I figured an issue when using to insert Javascript inside my CoffeeScript file.

In order to fix it, I searched for the similar plugin used by Sublime text.
You can find the reference here : 
https://github.com/aponxi/sublime-better-coffeescript/blob/master/CoffeeScript_Literate.tmLanguage#L668

To help you visualize the problem, here is a before/after capture : 

Before this fix :
![screenshot 2015-04-12 15 12 09](https://cloud.githubusercontent.com/assets/887094/7105728/8c3488fe-e127-11e4-9a59-911b485b278a.png)

After this fix :
![screenshot 2015-04-12 15 12 31](https://cloud.githubusercontent.com/assets/887094/7105729/8c35e348-e127-11e4-9723-bf578467c8da.png)

I'm here to help if you have more questions :) Thanks