### PR TITLE
Explicit test modifiers

### DIFF
--- a/grammars/coffeescript (literate).cson
+++ b/grammars/coffeescript (literate).cson
@@ -19,9 +19,9 @@
     ]
   }
   {
-    'begin': '(?x)^\n\t\t\t\t(?=\t[ ]{,3}>.\n\t\t\t\t|\t[#]{1,6}\\s*+\n\t\t\t\t|\t[ ]{,3}(?<marker>[-*_])([ ]{,2}\\k<marker>){2,}[ \\t]*+$\n\t\t\t\t)'
+    'begin': '(?x)^\n\t\t\t\t(?=\t[ ]{0,3}>.\n\t\t\t\t|\t[#]{1,6}\\s*+\n\t\t\t\t|\t[ ]{0,3}(?<marker>[-*_])([ ]{0,2}\\k<marker>){2,}[ \\t]*+$\n\t\t\t\t)'
     'comment': '\n\t\t\t\tWe could also use an empty end match and set\n\t\t\t\tapplyEndPatternLast, but then we must be sure that the begin\n\t\t\t\tpattern will only match stuff matched by the sub-patterns.\n\t\t\t'
-    'end': '(?x)^\n\t\t\t\t(?!\t[ ]{,3}>.\n\t\t\t\t|\t[#]{1,6}\\s*+\n\t\t\t\t|\t[ ]{,3}(?<marker>[-*_])([ ]{,2}\\k<marker>){2,}[ \\t]*+$\n\t\t\t\t)'
+    'end': '(?x)^\n\t\t\t\t(?!\t[ ]{0,3}>.\n\t\t\t\t|\t[#]{1,6}\\s*+\n\t\t\t\t|\t[ ]{0,3}(?<marker>[-*_])([ ]{0,2}\\k<marker>){2,}[ \\t]*+$\n\t\t\t\t)'
     'name': 'meta.block-level.markdown'
     'patterns': [
       {
@@ -116,7 +116,7 @@
   }
   {
     'begin': '^(?=\\S)(?![=-]{3,}(?=$))'
-    'end': '^(?:\\s*$|(?=[ ]{,3}>.))|(?=[ \\t]*\\n)(?<=^===|^====|=====|^---|^----|-----)[ \\t]*\\n|(?=^#)'
+    'end': '^(?:\\s*$|(?=[ ]{0,3}>.))|(?=[ \\t]*\\n)(?<=^===|^====|=====|^---|^----|-----)[ \\t]*\\n|(?=^#)'
     'name': 'meta.paragraph.markdown'
     'patterns': [
       {
@@ -148,16 +148,16 @@
     'match': '&(?!([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+);)'
     'name': 'meta.other.valid-ampersand.markdown'
   'block_quote':
-    'begin': '\\G[ ]{,3}(>)(?!$)[ ]?'
+    'begin': '\\G[ ]{0,3}(>)(?!$)[ ]?'
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.blockquote.markdown'
     'comment': '\n\t\t\t\tWe terminate the block quote when seeing an empty line, a\n\t\t\t\tseparator or a line with leading > characters. The latter is\n\t\t\t\tto “reset” the quote level for quoted lines.\n\t\t\t'
-    'end': '(?x)^\n\t\t\t\t(?=\t\\s*$\n\t\t\t\t|\t[ ]{,3}(?<marker>[-*_])([ ]{,2}\\k<marker>){2,}[ \\t]*+$\n\t\t\t\t|\t[ ]{,3}>.\n\t\t\t\t)'
+    'end': '(?x)^\n\t\t\t\t(?=\t\\s*$\n\t\t\t\t|\t[ ]{0,3}(?<marker>[-*_])([ ]{0,2}\\k<marker>){2,}[ \\t]*+$\n\t\t\t\t|\t[ ]{0,3}>.\n\t\t\t\t)'
     'name': 'markup.quote.markdown'
     'patterns': [
       {
-        'begin': '(?x)\\G\n\t\t\t\t\t\t(?=\t[ ]{,3}>.\n\t\t\t\t\t\t)'
+        'begin': '(?x)\\G\n\t\t\t\t\t\t(?=\t[ ]{0,3}>.\n\t\t\t\t\t\t)'
         'end': '^'
         'patterns': [
           {
@@ -167,7 +167,7 @@
       }
       {
         'applyEndPatternLast': 1
-        'begin': '(?x)\\G\n\t\t\t\t\t\t(?=\t([ ]{4}|\\t)\n\t\t\t\t\t\t|\t[#]{1,6}\\s*+\n\t\t\t\t\t\t|\t[ ]{,3}(?<marker>[-*_])([ ]{,2}\\k<marker>){2,}[ \\t]*+$\n\t\t\t\t\t\t)'
+        'begin': '(?x)\\G\n\t\t\t\t\t\t(?=\t([ ]{4}|\\t)\n\t\t\t\t\t\t|\t[#]{1,6}\\s*+\n\t\t\t\t\t\t|\t[ ]{0,3}(?<marker>[-*_])([ ]{0,2}\\k<marker>){2,}[ \\t]*+$\n\t\t\t\t\t\t)'
         'end': '^'
         'patterns': [
           {
@@ -182,7 +182,7 @@
         ]
       }
       {
-        'begin': '(?x)\\G\n\t\t\t\t\t\t(?!\t$\n\t\t\t\t\t\t|\t[ ]{,3}>.\n\t\t\t\t\t\t|\t([ ]{4}|\\t)\n\t\t\t\t\t\t|\t[#]{1,6}\\s*+\n\t\t\t\t\t\t|\t[ ]{,3}(?<marker>[-*_])([ ]{,2}\\k<marker>){2,}[ \\t]*+$\n\t\t\t\t\t\t)'
+        'begin': '(?x)\\G\n\t\t\t\t\t\t(?!\t$\n\t\t\t\t\t\t|\t[ ]{0,3}>.\n\t\t\t\t\t\t|\t([ ]{4}|\\t)\n\t\t\t\t\t\t|\t[#]{1,6}\\s*+\n\t\t\t\t\t\t|\t[ ]{0,3}(?<marker>[-*_])([ ]{0,2}\\k<marker>){2,}[ \\t]*+$\n\t\t\t\t\t\t)'
         'end': '$|(?<=\\n)'
         'patterns': [
           {
@@ -545,6 +545,6 @@
     'match': '(`+)([^`]|(?!(?<!`)\\1(?!`))`)*+(\\1)'
     'name': 'markup.raw.inline.markdown'
   'separator':
-    'match': '\\G[ ]{,3}([-*_])([ ]{,2}\\1){2,}[ \\t]*$\\n?'
+    'match': '\\G[ ]{0,3}([-*_])([ ]{0,2}\\1){2,}[ \\t]*$\\n?'
     'name': 'meta.separator.markdown'
 'scopeName': 'source.litcoffee'

--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -375,7 +375,7 @@
         'name': 'string.quoted.double.coffee'
         'patterns': [
           {
-            'match': '\\\\(x\\h{2}|[0-2][0-7]{,2}|3[0-6][0-7]|37[0-7]?|[4-7][0-7]?|.)'
+            'match': '\\\\(x\\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]|37[0-7]?|[4-7][0-7]?|.)'
             'name': 'constant.character.escape.coffee'
           }
           {
@@ -438,7 +438,7 @@
         'name': 'string.quoted.single.coffee'
         'patterns': [
           {
-            'match': '\\\\(x\\h{2}|[0-2][0-7]{,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)'
+            'match': '\\\\(x\\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)'
             'name': 'constant.character.escape.coffee'
           }
         ]

--- a/spec/coffee-script-spec.coffee
+++ b/spec/coffee-script-spec.coffee
@@ -1,3 +1,6 @@
+fs = require 'fs'
+path = require 'path'
+
 describe "CoffeeScript grammar", ->
   grammar = null
 
@@ -223,3 +226,10 @@ describe "CoffeeScript grammar", ->
     expect(tokens[1]).toEqual value: ":", scopes: ["source.coffee", "keyword.operator.coffee"]
     expect(tokens[2]).toEqual value: ":", scopes: ["source.coffee", "keyword.operator.coffee"]
     expect(tokens[3]).toEqual value: "extends", scopes: ["source.coffee"]
+
+  it "verifies that regular expressions have explicit count modifiers", ->
+    source = fs.readFileSync(path.resolve(__dirname, '..', 'grammars', 'coffeescript.cson'), 'utf8')
+    expect(source.search /{,/).toEqual -1
+
+    source = fs.readFileSync(path.resolve(__dirname, '..', 'grammars', 'coffeescript (literate).cson'), 'utf8')
+    expect(source.search /{,/).toEqual -1


### PR DESCRIPTION
The construction `{,2}` in regular expressions is only supported by Oniguruma (which is used by Atom). This Atom bundle is used to highlight CoffeeScript code on GitHub. However, GitHub is using a [PCRE-based engine](https://github.com/vmg/pcre) for regexes.

This pull request fixes that by using an explicit count modifier in the regex.