### PR TITLE
Tokenize functions parameters

### DIFF
--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -12,12 +12,12 @@
 'foldingStopMarker': '^\\s*$|^\\s*[}\\]]\\s*$'
 'patterns': [
   {
+    'comment': 'inline functions like: `->` or `(param1, param2) ->`'
     'captures':
       '1':
         'name': 'variable.parameter.function.coffee'
       '2':
         'name': 'storage.type.function.coffee'
-    'comment': 'match stuff like: a -> … '
     'match': '(\\([^()]*?\\))\\s*([=-]>)'
     'name': 'meta.inline.function.coffee'
   }

--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -19,7 +19,7 @@
       '2':
         'name': 'storage.type.function.coffee'
     'match': '(?x)
-      (\\([^()]*?\\))
+      (\\([^()]*?\\))?
       \\s*
       ([=-]>)
     '
@@ -235,10 +235,6 @@
   {
     'match': '@?\\b(?!class|subclass|extends|decodeURI(Component)?|encodeURI(Component)?|eval|parse(Float|Int)|require)\\w+(\\s+(?!(of|in|then|is|isnt|and|or|for|else|when|not|if)\\s)(?=(\\w+|\\->|\\-\\d|\\[|\\{|\"|\'))|(?=\\())'
     'name': 'entity.name.function.coffee'
-  }
-  {
-    'match': '[=-]>'
-    'name': 'storage.type.function.coffee'
   }
   {
     'match': '\\b(?<!\\.|::)(true|on|yes)(?!\\s*[:=][^=])\\b'

--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -12,18 +12,66 @@
 'foldingStopMarker': '^\\s*$|^\\s*[}\\]]\\s*$'
 'patterns': [
   {
-    'comment': 'inline functions like: `->` or `(param1, param2) ->`'
+    'comment': 'functions without parameters: `->`'
     'captures':
       '1':
-        'name': 'variable.parameter.function.coffee'
+        'name': 'punctuation.definition.parameters.begin.coffee'
       '2':
+        'name': 'punctuation.definition.parameters.end.coffee'
+      '3':
         'name': 'storage.type.function.coffee'
     'match': '(?x)
-      (\\([^()]*?\\))?
-      \\s*
+      (?:
+        (\\()
+        \\s*
+        (\\))
+        \\s*
+      )?
       ([=-]>)
     '
+    'name': 'meta.inline.function.without-parameters.coffee'
+  }
+  {
+    'comment': 'functions with parameters: `(param1, @param2) ->`'
+    'begin': '(?x)
+    (\\()
+    (?=
+      (?:
+        @?[a-zA-Z\\$_]\\w*|,|\\s
+      )*
+      \\)
+      \\s*
+      [=-]>
+    )
+    '
+    'beginCaptures':
+      '1':
+        'name': 'punctuation.definition.parameters.begin.coffee'
+    'end': '(\\))\\s*([=-]>)'
+    'endCaptures':
+      '1':
+        'name': 'punctuation.definition.parameters.end.coffee'
+      '2':
+        'name': 'storage.type.function.coffee'
     'name': 'meta.inline.function.coffee'
+    'patterns': [
+      {
+        'match': '(?x)
+          (@[a-zA-Z_\\$][\\w]*)|([a-zA-Z_\\$][\\w]*)
+          \\s*
+          (?:
+            (,)|(?=\\))
+          )
+        '
+        'captures':
+          '1':
+            'name': 'variable.parameter.function.readwrite.instance.coffee'
+          '2':
+            'name': 'variable.parameter.function.coffee'
+          '3':
+            'name': 'punctuation.separator.parameters.coffee'
+      }
+    ]
   }
   {
     'captures':

--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -18,7 +18,11 @@
         'name': 'variable.parameter.function.coffee'
       '2':
         'name': 'storage.type.function.coffee'
-    'match': '(\\([^()]*?\\))\\s*([=-]>)'
+    'match': '(?x)
+      (\\([^()]*?\\))
+      \\s*
+      ([=-]>)
+    '
     'name': 'meta.inline.function.coffee'
   }
   {

--- a/spec/coffee-script-spec.coffee
+++ b/spec/coffee-script-spec.coffee
@@ -199,6 +199,11 @@ describe "CoffeeScript grammar", ->
       {tokens} = grammar.tokenizeLine(notOperator)
       expect(tokens[0]).not.toEqual value: notOperator, scopes: ["source.coffee", "keyword.operator.coffee"]
 
+  it "tokenizes inline functions", ->
+    {tokens} = grammar.tokenizeLine("() ->")
+
+    expect(tokens[2]).toEqual value: "->", scopes: ["source.coffee", "meta.inline.function.coffee", "storage.type.function.coffee"]
+
   it "does not confuse prototype properties with constants and keywords", ->
     {tokens} = grammar.tokenizeLine("Foo::true")
     expect(tokens[0]).toEqual value: "Foo", scopes: ["source.coffee"]
@@ -269,7 +274,7 @@ describe "CoffeeScript grammar", ->
     expect(lines[0][1]).toEqual value: 'v', scopes: ["source.coffee", "string.quoted.script.coffee", "constant.character.escape.coffee"]
     expect(lines[1][0]).toEqual value: 'a ', scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee"]
 
-  it "tokenizes functions", ->
+  it "tokenizes functions calls", ->
     {tokens} = grammar.tokenizeLine("foo = -> 1")
     expect(tokens[0]).toEqual value: "foo ", scopes: ["source.coffee", "meta.function.coffee", "entity.name.function.coffee"]
 

--- a/spec/coffee-script-spec.coffee
+++ b/spec/coffee-script-spec.coffee
@@ -199,14 +199,34 @@ describe "CoffeeScript grammar", ->
       {tokens} = grammar.tokenizeLine(notOperator)
       expect(tokens[0]).not.toEqual value: notOperator, scopes: ["source.coffee", "keyword.operator.coffee"]
 
-  it "tokenizes inline functions", ->
+  it "tokenizes functions", ->
     {tokens} = grammar.tokenizeLine("->")
 
-    expect(tokens[0]).toEqual value: "->", scopes: ["source.coffee", "meta.inline.function.coffee", "storage.type.function.coffee"]
+    expect(tokens[0]).toEqual value: "->", scopes: ["source.coffee", "meta.inline.function.without-parameters.coffee", "storage.type.function.coffee"]
 
     {tokens} = grammar.tokenizeLine("() ->")
 
-    expect(tokens[2]).toEqual value: "->", scopes: ["source.coffee", "meta.inline.function.coffee", "storage.type.function.coffee"]
+    expect(tokens[0]).toEqual value: "(", scopes: ["source.coffee", "meta.inline.function.without-parameters.coffee", "punctuation.definition.parameters.begin.coffee"]
+    expect(tokens[1]).toEqual value: ")", scopes: ["source.coffee", "meta.inline.function.without-parameters.coffee", "punctuation.definition.parameters.end.coffee"]
+    expect(tokens[3]).toEqual value: "->", scopes: ["source.coffee", "meta.inline.function.without-parameters.coffee", "storage.type.function.coffee"]
+
+    {tokens} = grammar.tokenizeLine("(param1, param2) ->")
+
+    expect(tokens[0]).toEqual value: "(", scopes: ["source.coffee", "meta.inline.function.coffee", "punctuation.definition.parameters.begin.coffee"]
+    expect(tokens[1]).toEqual value: "param1", scopes: ["source.coffee", "meta.inline.function.coffee", "variable.parameter.function.coffee"]
+    expect(tokens[2]).toEqual value: ",", scopes: ["source.coffee", "meta.inline.function.coffee", "punctuation.separator.parameters.coffee"]
+    expect(tokens[4]).toEqual value: "param2", scopes: ["source.coffee", "meta.inline.function.coffee", "variable.parameter.function.coffee"]
+    expect(tokens[5]).toEqual value: ")", scopes: ["source.coffee", "meta.inline.function.coffee", "punctuation.definition.parameters.end.coffee"]
+    expect(tokens[7]).toEqual value: "->", scopes: ["source.coffee", "meta.inline.function.coffee", "storage.type.function.coffee"]
+
+    {tokens} = grammar.tokenizeLine("(param1, @param2) =>")
+
+    expect(tokens[0]).toEqual value: "(", scopes: ["source.coffee", "meta.inline.function.coffee", "punctuation.definition.parameters.begin.coffee"]
+    expect(tokens[1]).toEqual value: "param1", scopes: ["source.coffee", "meta.inline.function.coffee", "variable.parameter.function.coffee"]
+    expect(tokens[2]).toEqual value: ",", scopes: ["source.coffee", "meta.inline.function.coffee", "punctuation.separator.parameters.coffee"]
+    expect(tokens[4]).toEqual value: "@param2", scopes: ["source.coffee", "meta.inline.function.coffee", "variable.parameter.function.readwrite.instance.coffee"]
+    expect(tokens[5]).toEqual value: ")", scopes: ["source.coffee", "meta.inline.function.coffee", "punctuation.definition.parameters.end.coffee"]
+    expect(tokens[7]).toEqual value: "=>", scopes: ["source.coffee", "meta.inline.function.coffee", "storage.type.function.coffee"]
 
   it "does not confuse prototype properties with constants and keywords", ->
     {tokens} = grammar.tokenizeLine("Foo::true")

--- a/spec/coffee-script-spec.coffee
+++ b/spec/coffee-script-spec.coffee
@@ -200,6 +200,10 @@ describe "CoffeeScript grammar", ->
       expect(tokens[0]).not.toEqual value: notOperator, scopes: ["source.coffee", "keyword.operator.coffee"]
 
   it "tokenizes inline functions", ->
+    {tokens} = grammar.tokenizeLine("->")
+
+    expect(tokens[0]).toEqual value: "->", scopes: ["source.coffee", "meta.inline.function.coffee", "storage.type.function.coffee"]
+
     {tokens} = grammar.tokenizeLine("() ->")
 
     expect(tokens[2]).toEqual value: "->", scopes: ["source.coffee", "meta.inline.function.coffee", "storage.type.function.coffee"]


### PR DESCRIPTION
Fixes #63 

I couldn't make it work for functions
with multiline parameters:

``` coffee
(param1
  param2) -> x * x
```

with function-calls:

``` coffee
(bar, bar2=test()) ->
```
