### PR TITLE
Fix duplicate tokens and token boundaries

### DIFF
--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -224,7 +224,13 @@
         'name': 'variable.parameter.function.coffee'
       '4':
         'name': 'storage.type.function.coffee'
-    'match': '(?<=^|\\s)(?=@?[a-zA-Z\\$_])@?([a-zA-Z\\$_]\\w*)(\\$|:|\\.)?\\s*(?=[:=](\\s*\\(.*\\))?\\s*([=-]>))'
+    'match': '''
+              (?x)
+              (?<=^|\\s)
+              (?=@?[a-zA-Z\\$_])
+              @?([a-zA-Z\\$_]\\w*)(\\$|:|\\.)?\\s*
+              (?=[:=](\\s*\\(.*\\))?\\s*([=-]>))
+            '''
     'name': 'meta.function.coffee'
   }
   {

--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -224,7 +224,6 @@
         'name': 'variable.parameter.function.coffee'
       '4':
         'name': 'storage.type.function.coffee'
-<<<<<<< HEAD
     'match': '''
               (?x)
               (?<=^|\\s)
@@ -232,9 +231,6 @@
               @?([a-zA-Z\\$_]\\w*)(\\$|:|\\.)?\\s*
               (?=[:=](\\s*\\(.*\\))?\\s*([=-]>))
             '''
-=======
-    'match': '(?<=^|\\s)(?=@?[a-zA-Z\\$_])(@?[a-zA-Z\\$_](\\w|\\$|:|\\.)*\\s*(?=[:=](\\s*\\(.*\\))?\\s*([=-]>)))'
->>>>>>> master
     'name': 'meta.function.coffee'
   }
   {

--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -154,12 +154,11 @@
     'captures':
       '1':
         'name': 'variable.assignment.coffee'
-      '4':
+      '3':
         'name': 'punctuation.separator.key-value'
-      '5':
+      '4':
         'name': 'keyword.operator.coffee'
-    'match': '([a-zA-Z\\$_](\\w|\\$|\\.)*\\s*(?!\\::)((:)|((?:or|and|[-+/&%*?])?=)(?![>=]))(?!(\\s*\\(.*\\))?\\s*([=-]>)))'
-    'name': 'variable.assignment.coffee'
+    'match': '([a-zA-Z\\$_])(\\w|\\$|\\.)*\\s*(?!::)(?:(:)|((?:or|and|[-+\\/&%*?])?=)(?![>=]))(?!(\\s*\\(.*\\))?\\s*([=-]>))'
   }
   {
     'begin': '(?<=\\s|^)(\\{)(?=.+?\\}\\s+[:=])'
@@ -225,12 +224,14 @@
         'name': 'variable.parameter.function.coffee'
       '4':
         'name': 'storage.type.function.coffee'
-    'match': '(?x)\n\t\t\t\t(?<=^|\\s)\n\t\t\t\t(?=@?[a-zA-Z\\$_])\n\t\t\t\t(\n\t\t\t\t\t@?[a-zA-Z\\$_](\\w|\\$|:|\\.)*\\s*\n\t\t\t\t\t(?=[:=](\\s*\\(.*\\))?\\s*([=-]>))\n\t\t\t\t)\n\t\t\t'
+    'match': '(?<=^|\\s)(?=@?[a-zA-Z\\$_])@?([a-zA-Z\\$_]\\w*)(\\$|:|\\.)?\\s*(?=[:=](\\s*\\(.*\\))?\\s*([=-]>))'
     'name': 'meta.function.coffee'
   }
   {
-    'match': '@?\\b(?!class|subclass|extends|decodeURI(Component)?|encodeURI(Component)?|eval|parse(Float|Int)|require)\\w+(\\s+(?!(of|in|then|is|isnt|and|or|for|else|when|not|if)\\s)(?=(\\w+|\\->|\\-\\d|\\[|\\{|\"|\'))|(?=\\())'
-    'name': 'entity.name.function.coffee'
+    'captures':
+      '4':
+        'name': 'entity.name.function.coffee'
+    'match': '@?\\b(?!class|subclass|extends|decodeURI(Component)?|encodeURI(Component)?|eval|parse(Float|Int)|require)(\\w+)(?:\\s+(?!(of|in|then|is|isnt|and|or|for|else|when|not|if)\\b)(?=(\\w+|\\->|\\-\\d|\\[|\\{|\"|\'))|(?=\\())'
   }
   {
     'match': '[=-]>'

--- a/spec/coffee-script-spec.coffee
+++ b/spec/coffee-script-spec.coffee
@@ -100,54 +100,54 @@ describe "CoffeeScript grammar", ->
 
   it "tokenizes variable assignments", ->
     {tokens} = grammar.tokenizeLine("a = b")
-    expect(tokens[0]).toEqual value: "a ", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee"]
-    expect(tokens[1]).toEqual value: "=", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee", "keyword.operator.coffee"]
-    expect(tokens[2]).toEqual value: " b", scopes: ["source.coffee"]
+    expect(tokens[0]).toEqual value: "a", scopes: ["source.coffee", "variable.assignment.coffee"]
+    expect(tokens[2]).toEqual value: "=", scopes: ["source.coffee", "keyword.operator.coffee"]
+    expect(tokens[3]).toEqual value: " b", scopes: ["source.coffee"]
 
     {tokens} = grammar.tokenizeLine("a and= b")
-    expect(tokens[0]).toEqual value: "a ", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee"]
-    expect(tokens[1]).toEqual value: "and=", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee", "keyword.operator.coffee"]
-    expect(tokens[2]).toEqual value: " b", scopes: ["source.coffee"]
+    expect(tokens[0]).toEqual value: "a", scopes: ["source.coffee", "variable.assignment.coffee"]
+    expect(tokens[2]).toEqual value: "and=", scopes: ["source.coffee", "keyword.operator.coffee"]
+    expect(tokens[3]).toEqual value: " b", scopes: ["source.coffee"]
 
     {tokens} = grammar.tokenizeLine("a or= b")
-    expect(tokens[0]).toEqual value: "a ", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee"]
-    expect(tokens[1]).toEqual value: "or=", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee", "keyword.operator.coffee"]
-    expect(tokens[2]).toEqual value: " b", scopes: ["source.coffee"]
+    expect(tokens[0]).toEqual value: "a", scopes: ["source.coffee", "variable.assignment.coffee"]
+    expect(tokens[2]).toEqual value: "or=", scopes: ["source.coffee", "keyword.operator.coffee"]
+    expect(tokens[3]).toEqual value: " b", scopes: ["source.coffee"]
 
     {tokens} = grammar.tokenizeLine("a -= b")
-    expect(tokens[0]).toEqual value: "a ", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee"]
-    expect(tokens[1]).toEqual value: "-=", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee", "keyword.operator.coffee"]
-    expect(tokens[2]).toEqual value: " b", scopes: ["source.coffee"]
+    expect(tokens[0]).toEqual value: "a", scopes: ["source.coffee", "variable.assignment.coffee"]
+    expect(tokens[2]).toEqual value: "-=", scopes: ["source.coffee", "keyword.operator.coffee"]
+    expect(tokens[3]).toEqual value: " b", scopes: ["source.coffee"]
 
     {tokens} = grammar.tokenizeLine("a += b")
-    expect(tokens[0]).toEqual value: "a ", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee"]
-    expect(tokens[1]).toEqual value: "+=", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee", "keyword.operator.coffee"]
-    expect(tokens[2]).toEqual value: " b", scopes: ["source.coffee"]
+    expect(tokens[0]).toEqual value: "a", scopes: ["source.coffee", "variable.assignment.coffee"]
+    expect(tokens[2]).toEqual value: "+=", scopes: ["source.coffee", "keyword.operator.coffee"]
+    expect(tokens[3]).toEqual value: " b", scopes: ["source.coffee"]
 
     {tokens} = grammar.tokenizeLine("a /= b")
-    expect(tokens[0]).toEqual value: "a ", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee"]
-    expect(tokens[1]).toEqual value: "/=", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee", "keyword.operator.coffee"]
-    expect(tokens[2]).toEqual value: " b", scopes: ["source.coffee"]
+    expect(tokens[0]).toEqual value: "a", scopes: ["source.coffee", "variable.assignment.coffee"]
+    expect(tokens[2]).toEqual value: "/=", scopes: ["source.coffee", "keyword.operator.coffee"]
+    expect(tokens[3]).toEqual value: " b", scopes: ["source.coffee"]
 
     {tokens} = grammar.tokenizeLine("a &= b")
-    expect(tokens[0]).toEqual value: "a ", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee"]
-    expect(tokens[1]).toEqual value: "&=", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee", "keyword.operator.coffee"]
-    expect(tokens[2]).toEqual value: " b", scopes: ["source.coffee"]
+    expect(tokens[0]).toEqual value: "a", scopes: ["source.coffee", "variable.assignment.coffee"]
+    expect(tokens[2]).toEqual value: "&=", scopes: ["source.coffee", "keyword.operator.coffee"]
+    expect(tokens[3]).toEqual value: " b", scopes: ["source.coffee"]
 
     {tokens} = grammar.tokenizeLine("a %= b")
-    expect(tokens[0]).toEqual value: "a ", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee"]
-    expect(tokens[1]).toEqual value: "%=", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee", "keyword.operator.coffee"]
-    expect(tokens[2]).toEqual value: " b", scopes: ["source.coffee"]
+    expect(tokens[0]).toEqual value: "a", scopes: ["source.coffee", "variable.assignment.coffee"]
+    expect(tokens[2]).toEqual value: "%=", scopes: ["source.coffee", "keyword.operator.coffee"]
+    expect(tokens[3]).toEqual value: " b", scopes: ["source.coffee"]
 
     {tokens} = grammar.tokenizeLine("a *= b")
-    expect(tokens[0]).toEqual value: "a ", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee"]
-    expect(tokens[1]).toEqual value: "*=", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee", "keyword.operator.coffee"]
-    expect(tokens[2]).toEqual value: " b", scopes: ["source.coffee"]
+    expect(tokens[0]).toEqual value: "a", scopes: ["source.coffee", "variable.assignment.coffee"]
+    expect(tokens[2]).toEqual value: "*=", scopes: ["source.coffee", "keyword.operator.coffee"]
+    expect(tokens[3]).toEqual value: " b", scopes: ["source.coffee"]
 
     {tokens} = grammar.tokenizeLine("a ?= b")
-    expect(tokens[0]).toEqual value: "a ", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee"]
-    expect(tokens[1]).toEqual value: "?=", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee", "keyword.operator.coffee"]
-    expect(tokens[2]).toEqual value: " b", scopes: ["source.coffee"]
+    expect(tokens[0]).toEqual value: "a", scopes: ["source.coffee", "variable.assignment.coffee"]
+    expect(tokens[2]).toEqual value: "?=", scopes: ["source.coffee", "keyword.operator.coffee"]
+    expect(tokens[3]).toEqual value: " b", scopes: ["source.coffee"]
 
     {tokens} = grammar.tokenizeLine("a == b")
     expect(tokens[0]).toEqual value: "a ", scopes: ["source.coffee"]
@@ -246,19 +246,20 @@ describe "CoffeeScript grammar", ->
       """
     expect(lines[0][0]).toEqual value: '`', scopes: ["source.coffee", "string.quoted.script.coffee", "punctuation.definition.string.begin.coffee"]
     expect(lines[0][1]).toEqual value: 'v', scopes: ["source.coffee", "string.quoted.script.coffee", "constant.character.escape.coffee"]
-    expect(lines[1][0]).toEqual value: 'a ', scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee"]
+    expect(lines[1][0]).toEqual value: 'a', scopes: ["source.coffee", "variable.assignment.coffee"]
 
   it "tokenizes functions", ->
     {tokens} = grammar.tokenizeLine("foo = -> 1")
-    expect(tokens[0]).toEqual value: "foo ", scopes: ["source.coffee", "meta.function.coffee", "entity.name.function.coffee"]
+    expect(tokens[0]).toEqual value: "foo", scopes: ["source.coffee", "meta.function.coffee", "entity.name.function.coffee"]
 
     {tokens} = grammar.tokenizeLine("foo bar")
-    expect(tokens[0]).toEqual value: "foo ", scopes: ["source.coffee", "entity.name.function.coffee"]
+    expect(tokens[0]).toEqual value: "foo", scopes: ["source.coffee", "entity.name.function.coffee"]
 
     {tokens} = grammar.tokenizeLine("eat food for food in foods")
-    expect(tokens[0]).toEqual value: "eat ", scopes: ["source.coffee", "entity.name.function.coffee"]
-    expect(tokens[1]).toEqual value: "food ", scopes: ["source.coffee"]
-    expect(tokens[2]).toEqual value: "for", scopes: ["source.coffee", "keyword.control.coffee"]
-    expect(tokens[3]).toEqual value: " food ", scopes: ["source.coffee"]
-    expect(tokens[4]).toEqual value: "in", scopes: ["source.coffee", "keyword.control.coffee"]
-    expect(tokens[5]).toEqual value: " foods", scopes: ["source.coffee"]
+    expect(tokens[0]).toEqual value: "eat", scopes: ["source.coffee", "entity.name.function.coffee"]
+    expect(tokens[1]).toEqual value: " ", scopes: ["source.coffee"]
+    expect(tokens[2]).toEqual value: "food ", scopes: ["source.coffee"]
+    expect(tokens[3]).toEqual value: "for", scopes: ["source.coffee", "keyword.control.coffee"]
+    expect(tokens[4]).toEqual value: " food ", scopes: ["source.coffee"]
+    expect(tokens[5]).toEqual value: "in", scopes: ["source.coffee", "keyword.control.coffee"]
+    expect(tokens[6]).toEqual value: " foods", scopes: ["source.coffee"]


### PR DESCRIPTION
This PR does two things:
1. Remove duplicate tokens.  The `variable.assignment` tokens were being duplicated, so I fixed that.
2. Fix token boundaries.  Some whitespace was being tokenized inadvertently (eg `a ` being tokenized as `entity.name.function`, which isn't right.