### PR TITLE
Update coffeescript literate spaces

### DIFF
--- a/grammars/coffeescript (literate).cson
+++ b/grammars/coffeescript (literate).cson
@@ -4,13 +4,23 @@
   'litcoffee.erb'
   'coffee.md'
 ]
-'foldingStartMarker': '(?x)\n\t\t(<(?i:head|body|table|thead|tbody|tfoot|tr|div|select|fieldset|style|script|ul|ol|form|dl)\\b.*?>\n\t\t|<!--(?!.*-->)\n\t\t|\\{\\s*($|\\?>\\s*$|//|/\\*(.*\\*/\\s*$|(?!.*?\\*/)))\n\t\t)'
-'foldingStopMarker': '(?x)\n\t\t(</(?i:head|body|table|thead|tbody|tfoot|tr|div|select|fieldset|style|script|ul|ol|form|dl)>\n\t\t|^\\s*-->\n\t\t|(^|\\s)\\}\n\t\t)'
+'foldingStartMarker': '(?x)
+                       (<(?i:head|body|table|thead|tbody|tfoot|tr|div|select|fieldset|style|script|ul|ol|form|dl)\\b.*?>
+                       |<!--(?!.*-->)
+                       |\\{\\s*($|\\?>\\s*$|//|/\\*(.*\\*/\\s*$|(?!.*?\\*/)))
+                       )'
+'foldingStopMarker': '(?x)
+                      (</(?i:head|body|table|thead|tbody|tfoot|tr|div|select|fieldset|style|script|ul|ol|form|dl)>
+                      |^\\s*-->
+                      |(^|\\s)\\}
+                      )'
 'name': 'CoffeeScript (Literate)'
 'patterns': [
   {
-    'begin': '(?x)^\n\t\t\t\t(?=\t([ ]{4}|\\t)(?!$))'
-    'end': '(?x)^\n\t\t\t\t(?!\t([ ]{4}|\\t))'
+    'begin': '(?x)^
+              (?=  ([ ]{4}|\\t)(?!$))'
+    'end': '(?x)^
+            (?!  ([ ]{4}|\\t))'
     'name': 'markup.raw.block.markdown'
     'patterns': [
       {
@@ -19,9 +29,17 @@
     ]
   }
   {
-    'begin': '(?x)^\n\t\t\t\t(?=\t[ ]{0,3}>.\n\t\t\t\t|\t[#]{1,6}\\s*+\n\t\t\t\t|\t[ ]{0,3}(?<marker>[-*_])([ ]{0,2}\\k<marker>){2,}[ \\t]*+$\n\t\t\t\t)'
-    'comment': '\n\t\t\t\tWe could also use an empty end match and set\n\t\t\t\tapplyEndPatternLast, but then we must be sure that the begin\n\t\t\t\tpattern will only match stuff matched by the sub-patterns.\n\t\t\t'
-    'end': '(?x)^\n\t\t\t\t(?!\t[ ]{0,3}>.\n\t\t\t\t|\t[#]{1,6}\\s*+\n\t\t\t\t|\t[ ]{0,3}(?<marker>[-*_])([ ]{0,2}\\k<marker>){2,}[ \\t]*+$\n\t\t\t\t)'
+    'begin': '(?x)^
+              (?=  [ ]{0,3}>.
+              |  [#]{1,6}\\s*+
+              |  [ ]{0,3}(?<marker>[-*_])([ ]{0,2}\\k<marker>){2,}[ \\t]*+$
+              )'
+    'comment': 'We could also use an empty end match and set applyEndPatternLast, but then we must be sure that the begin pattern will only match stuff matched by the sub-patterns.'
+    'end': '(?x)^
+            (?!  [ ]{0,3}>.
+            |  [#]{1,6}\\s*+
+            |  [ ]{0,3}(?<marker>[-*_])([ ]{0,2}\\k<marker>){2,}[ \\t]*+$
+            )'
     'name': 'meta.block-level.markdown'
     'patterns': [
       {
@@ -63,7 +81,7 @@
   }
   {
     'begin': '^(?=<(p|div|h[1-6]|blockquote|pre|table|dl|ol|ul|script|noscript|form|fieldset|iframe|math|ins|del)\\b)(?!.*?</\\1>)'
-    'comment': '\n\t\t\t\tMarkdown formatting is disabled inside block-level tags.\n\t\t\t'
+    'comment': 'Markdown formatting is disabled inside block-level tags.'
     'end': '(?<=^</\\1>$\\n)'
     'name': 'meta.disable-markdown'
     'patterns': [
@@ -111,7 +129,19 @@
         'name': 'punctuation.definition.string.begin.markdown'
       '13':
         'name': 'punctuation.definition.string.end.markdown'
-    'match': '(?x:\n\t\t\t\t\\s*\t\t\t\t\t\t# Leading whitespace\n\t\t\t\t(\\[)(.+?)(\\])(:)\t\t# Reference name\n\t\t\t\t[ \\t]*\t\t\t\t\t# Optional whitespace\n\t\t\t\t(<?)(\\S+?)(>?)\t\t\t# The url\n\t\t\t\t[ \\t]*\t\t\t\t\t# Optional whitespace\n\t\t\t\t(?:\n\t\t\t\t\t  ((\\().+?(\\)))\t\t# Match title in quotes…\n\t\t\t\t\t| ((").+?("))\t\t# or in parens.\n\t\t\t\t)?\t\t\t\t\t\t# Title is optional\n\t\t\t\t\\s*\t\t\t\t\t\t# Optional whitespace\n\t\t\t\t$\n\t\t\t)'
+    'match': '(?x:
+                \\s*                    # Leading whitespace
+                (\\[)(.+?)(\\])(:)      # Reference name
+                [ \\t]*                 # Optional whitespace
+                (<?)(\\S+?)(>?)         # The url
+                [ \\t]*                 # Optional whitespace
+                (?:
+                    ((\\().+?(\\)))     # Match title in quotes…
+                  | ((").+?("))         # or in parens.
+                )?                      # Title is optional
+                \\s*                    # Optional whitespace
+                $
+              )'
     'name': 'meta.link.reference.def.markdown'
   }
   {
@@ -144,7 +174,7 @@
 ]
 'repository':
   'ampersand':
-    'comment': '\n\t\t\t\tMarkdown will convert this for us. We match it so that the\n\t\t\t\tHTML grammar will not mark it up as invalid.\n\t\t\t'
+    'comment': 'Markdown will convert this for us. We match it so that the HTML grammar will not mark it up as invalid.'
     'match': '&(?!([a-zA-Z0-9]+|#[0-9]+|#x[0-9a-fA-F]+);)'
     'name': 'meta.other.valid-ampersand.markdown'
   'block_quote':
@@ -152,12 +182,18 @@
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.blockquote.markdown'
-    'comment': '\n\t\t\t\tWe terminate the block quote when seeing an empty line, a\n\t\t\t\tseparator or a line with leading > characters. The latter is\n\t\t\t\tto “reset” the quote level for quoted lines.\n\t\t\t'
-    'end': '(?x)^\n\t\t\t\t(?=\t\\s*$\n\t\t\t\t|\t[ ]{0,3}(?<marker>[-*_])([ ]{0,2}\\k<marker>){2,}[ \\t]*+$\n\t\t\t\t|\t[ ]{0,3}>.\n\t\t\t\t)'
+    'comment': ' We terminate the block quote when seeing an empty line, a separator or a line with leading > characters. The latter is to “reset” the quote level for quoted lines.'
+    'end': '(?x)^
+            (?=  \\s*$
+            |  [ ]{0,3}(?<marker>[-*_])([ ]{0,2}\\k<marker>){2,}[ \\t]*+$
+            |  [ ]{0,3}>.
+            )'
     'name': 'markup.quote.markdown'
     'patterns': [
       {
-        'begin': '(?x)\\G\n\t\t\t\t\t\t(?=\t[ ]{0,3}>.\n\t\t\t\t\t\t)'
+        'begin': '(?x)\\G
+                  (?=  [ ]{0,3}>.
+                  )'
         'end': '^'
         'patterns': [
           {
@@ -167,7 +203,11 @@
       }
       {
         'applyEndPatternLast': 1
-        'begin': '(?x)\\G\n\t\t\t\t\t\t(?=\t([ ]{4}|\\t)\n\t\t\t\t\t\t|\t[#]{1,6}\\s*+\n\t\t\t\t\t\t|\t[ ]{0,3}(?<marker>[-*_])([ ]{0,2}\\k<marker>){2,}[ \\t]*+$\n\t\t\t\t\t\t)'
+        'begin': '(?x)\\G
+                  (?=  ([ ]{4}|\\t)
+                  |  [#]{1,6}\\s*+
+                  |  [ ]{0,3}(?<marker>[-*_])([ ]{0,2}\\k<marker>){2,}[ \\t]*+$
+                  )'
         'end': '^'
         'patterns': [
           {
@@ -182,7 +222,13 @@
         ]
       }
       {
-        'begin': '(?x)\\G\n\t\t\t\t\t\t(?!\t$\n\t\t\t\t\t\t|\t[ ]{0,3}>.\n\t\t\t\t\t\t|\t([ ]{4}|\\t)\n\t\t\t\t\t\t|\t[#]{1,6}\\s*+\n\t\t\t\t\t\t|\t[ ]{0,3}(?<marker>[-*_])([ ]{0,2}\\k<marker>){2,}[ \\t]*+$\n\t\t\t\t\t\t)'
+        'begin': '(?x)\\G
+                  (?!  $
+                  |  [ ]{0,3}>.
+                  |  ([ ]{4}|\\t)
+                  |  [#]{1,6}\\s*+
+                  |  [ ]{0,3}(?<marker>[-*_])([ ]{0,2}\\k<marker>){2,}[ \\t]*+$
+                  )'
         'end': '$|(?<=\\n)'
         'patterns': [
           {
@@ -199,7 +245,46 @@
       }
     ]
   'bold':
-    'begin': '(?x)\n\t\t\t\t\t\t(\\*\\*|__)(?=\\S)\t\t\t\t\t\t\t\t# Open\n\t\t\t\t\t\t(?=\n\t\t\t\t\t\t\t(\n\t\t\t\t\t\t\t    <[^>]*+>\t\t\t\t\t\t\t# HTML tags\n\t\t\t\t\t\t\t  | (?<raw>`+)([^`]|(?!(?<!`)\\k<raw>(?!`))`)*+\\k<raw>\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t# Raw\n\t\t\t\t\t\t\t  | \\\\[\\\\`*_{}\\[\\]()#.!+\\->]?+\t\t\t# Escapes\n\t\t\t\t\t\t\t  | \\[\n\t\t\t\t\t\t\t\t(\n\t\t\t\t\t\t\t\t        (?<square>\t\t\t\t\t# Named group\n\t\t\t\t\t\t\t\t\t\t\t[^\\[\\]\\\\]\t\t\t\t# Match most chars\n\t\t\t\t\t\t\t\t          | \\\\.\t\t\t\t\t\t# Escaped chars\n\t\t\t\t\t\t\t\t          | \\[ \\g<square>*+ \\]\t\t# Nested brackets\n\t\t\t\t\t\t\t\t        )*+\n\t\t\t\t\t\t\t\t\t\\]\n\t\t\t\t\t\t\t\t\t(\n\t\t\t\t\t\t\t\t\t\t(\t\t\t\t\t\t\t# Reference Link\n\t\t\t\t\t\t\t\t\t\t\t[ ]?\t\t\t\t\t# Optional space\n\t\t\t\t\t\t\t\t\t\t\t\\[[^\\]]*+\\]\t\t\t\t# Ref name\n\t\t\t\t\t\t\t\t\t\t)\n\t\t\t\t\t\t\t\t\t  | (\t\t\t\t\t\t\t# Inline Link\n\t\t\t\t\t\t\t\t\t\t\t\\(\t\t\t\t\t\t# Opening paren\n\t\t\t\t\t\t\t\t\t\t\t\t[ \\t]*+\t\t\t\t# Optional whtiespace\n\t\t\t\t\t\t\t\t\t\t\t\t<?(.*?)>?\t\t\t# URL\n\t\t\t\t\t\t\t\t\t\t\t\t[ \\t]*+\t\t\t\t# Optional whtiespace\n\t\t\t\t\t\t\t\t\t\t\t\t(\t\t\t\t\t# Optional Title\n\t\t\t\t\t\t\t\t\t\t\t\t\t(?<title>[\'"])\n\t\t\t\t\t\t\t\t\t\t\t\t\t(.*?)\n\t\t\t\t\t\t\t\t\t\t\t\t\t\\k<title>\n\t\t\t\t\t\t\t\t\t\t\t\t)?\n\t\t\t\t\t\t\t\t\t\t\t\\)\n\t\t\t\t\t\t\t\t\t\t)\n\t\t\t\t\t\t\t\t\t)\n\t\t\t\t\t\t\t\t)\n\t\t\t\t\t\t\t  | (?!(?<=\\S)\\1).\t\t\t\t\t\t# Everything besides\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t# style closer\n\t\t\t\t\t\t\t)++\n\t\t\t\t\t\t\t(?<=\\S)\\1\t\t\t\t\t\t\t\t# Close\n\t\t\t\t\t\t)\n\t\t\t\t\t'
+    'begin': '(?x)
+              (\\*\\*|__)(?=\\S)                                          # Open
+              (?=
+                (
+                    <[^>]*+>                                              # HTML tags
+                  | (?<raw>`+)([^`]|(?!(?<!`)\\k<raw>(?!`))`)*+\\k<raw>   # Raw
+                  | \\\\[\\\\`*_{}\\[\\]()#.!+\\->]?+                     # Escapes
+                  | \\[
+                  (
+                          (?<square>                                      # Named group
+                        [^\\[\\]\\\\]                                     # Match most chars
+                            | \\\\.                                       # Escaped chars
+                            | \\[ \\g<square>*+ \\]                       # Nested brackets
+                          )*+
+                    \\]
+                    (
+                      (                                                   # Reference Link
+                        [ ]?                                              # Optional space
+                        \\[[^\\]]*+\\]                                    # Ref name
+                      )
+                      | (                                                 # Inline Link
+                        \\(                                               # Opening paren
+                          [ \\t]*+                                        # Optional whtiespace
+                          <?(.*?)>?                                       # URL
+                          [ \\t]*+                                        # Optional whtiespace
+                          (                                               # Optional Title
+                            (?<title>[\'"])
+                            (.*?)
+                            \\k<title>
+                          )?
+                        \\)
+                      )
+                    )
+                  )
+                  | (?!(?<=\\S)\\1).                                      # Everything besides
+                                                                          # style closer
+                )++
+                (?<=\\S)\\1                                               # Close
+              )
+            '
     'captures':
       '1':
         'name': 'punctuation.definition.bold.markdown'
@@ -254,7 +339,7 @@
       }
     ]
   'bracket':
-    'comment': '\n\t\t\t\tMarkdown will convert this for us. We match it so that the\n\t\t\t\tHTML grammar will not mark it up as invalid.\n\t\t\t'
+    'comment': 'Markdown will convert this for us. We match it so that the HTML grammar will not mark it up as invalid.'
     'match': '<(?![a-z/?\\$!])'
     'name': 'meta.other.valid-bracket.markdown'
   'coffee_script':
@@ -311,7 +396,21 @@
         'name': 'punctuation.definition.string.markdown'
       '16':
         'name': 'punctuation.definition.metadata.markdown'
-    'match': '(?x:\n\t\t\t\t\\!\t\t\t\t\t\t\t# Images start with !\n\t\t\t\t(\\[)((?<square>[^\\[\\]\\\\]|\\\\.|\\[\\g<square>*+\\])*+)(\\])\n\t\t\t\t\t\t\t\t\t\t\t# Match the link text.\n\t\t\t\t([ ])?\t\t\t\t\t\t# Space not allowed\n\t\t\t\t(\\()\t\t\t\t\t\t# Opening paren for url\n\t\t\t\t\t(<?)(\\S+?)(>?)\t\t\t# The url\n\t\t\t\t\t[ \\t]*\t\t\t\t\t# Optional whitespace\n\t\t\t\t\t(?:\n\t\t\t\t\t\t  ((\\().+?(\\)))\t\t# Match title in parens…\n\t\t\t\t\t\t| ((").+?("))\t\t# or in quotes.\n\t\t\t\t\t)?\t\t\t\t\t\t# Title is optional\n\t\t\t\t\t\\s*\t\t\t\t\t\t# Optional whitespace\n\t\t\t\t(\\))\n\t\t\t )'
+    'match': '(?x:
+              \\!                       # Images start with !
+              (\\[)((?<square>[^\\[\\]\\\\]|\\\\.|\\[\\g<square>*+\\])*+)(\\])
+                                        # Match the link text.
+              ([ ])?                    # Space not allowed
+              (\\()                     # Opening paren for url
+                (<?)(\\S+?)(>?)         # The url
+                [ \\t]*                 # Optional whitespace
+                (?:
+                    ((\\().+?(\\)))     # Match title in parens…
+                  | ((").+?("))         # or in quotes.
+                )?                      # Title is optional
+                \\s*                    # Optional whitespace
+              (\\))
+             )'
     'name': 'meta.image.inline.markdown'
   'image-ref':
     'captures':
@@ -375,7 +474,48 @@
       }
     ]
   'italic':
-    'begin': '(?x)\n\t\t\t\t\t\t(\\*|_)(?=\\S)\t\t\t\t\t\t\t\t# Open\n\t\t\t\t\t\t(?=\n\t\t\t\t\t\t\t(\n\t\t\t\t\t\t\t    <[^>]*+>\t\t\t\t\t\t\t# HTML tags\n\t\t\t\t\t\t\t  | (?<raw>`+)([^`]|(?!(?<!`)\\k<raw>(?!`))`)*+\\k<raw>\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t# Raw\n\t\t\t\t\t\t\t  | \\\\[\\\\`*_{}\\[\\]()#.!+\\->]?+\t\t\t# Escapes\n\t\t\t\t\t\t\t  | \\[\n\t\t\t\t\t\t\t\t(\n\t\t\t\t\t\t\t\t        (?<square>\t\t\t\t\t# Named group\n\t\t\t\t\t\t\t\t\t\t\t[^\\[\\]\\\\]\t\t\t\t# Match most chars\n\t\t\t\t\t\t\t\t          | \\\\.\t\t\t\t\t\t# Escaped chars\n\t\t\t\t\t\t\t\t          | \\[ \\g<square>*+ \\]\t\t# Nested brackets\n\t\t\t\t\t\t\t\t        )*+\n\t\t\t\t\t\t\t\t\t\\]\n\t\t\t\t\t\t\t\t\t(\n\t\t\t\t\t\t\t\t\t\t(\t\t\t\t\t\t\t# Reference Link\n\t\t\t\t\t\t\t\t\t\t\t[ ]?\t\t\t\t\t# Optional space\n\t\t\t\t\t\t\t\t\t\t\t\\[[^\\]]*+\\]\t\t\t\t# Ref name\n\t\t\t\t\t\t\t\t\t\t)\n\t\t\t\t\t\t\t\t\t  | (\t\t\t\t\t\t\t# Inline Link\n\t\t\t\t\t\t\t\t\t\t\t\\(\t\t\t\t\t\t# Opening paren\n\t\t\t\t\t\t\t\t\t\t\t\t[ \\t]*+\t\t\t\t# Optional whtiespace\n\t\t\t\t\t\t\t\t\t\t\t\t<?(.*?)>?\t\t\t# URL\n\t\t\t\t\t\t\t\t\t\t\t\t[ \\t]*+\t\t\t\t# Optional whtiespace\n\t\t\t\t\t\t\t\t\t\t\t\t(\t\t\t\t\t# Optional Title\n\t\t\t\t\t\t\t\t\t\t\t\t\t(?<title>[\'"])\n\t\t\t\t\t\t\t\t\t\t\t\t\t(.*?)\n\t\t\t\t\t\t\t\t\t\t\t\t\t\\k<title>\n\t\t\t\t\t\t\t\t\t\t\t\t)?\n\t\t\t\t\t\t\t\t\t\t\t\\)\n\t\t\t\t\t\t\t\t\t\t)\n\t\t\t\t\t\t\t\t\t)\n\t\t\t\t\t\t\t\t)\n\t\t\t\t\t\t\t  | \\1\\1\t\t\t\t\t\t\t\t# Must be bold closer\n\t\t\t\t\t\t\t  | (?!(?<=\\S)\\1).\t\t\t\t\t\t# Everything besides\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t# style closer\n\t\t\t\t\t\t\t)++\n\t\t\t\t\t\t\t(?<=\\S)\\1\t\t\t\t\t\t\t\t# Close\n\t\t\t\t\t\t)\n\t\t\t\t\t'
+    'begin': '(?x)
+              (\\*|_)(?=\\S)                            # Open
+              (?=
+                (
+                    <[^>]*+>                            # HTML tags
+                  | (?<raw>`+)([^`]|(?!(?<!`)\\k<raw>(?!`))`)*+\\k<raw>
+                                    # Raw
+                  | \\\\[\\\\`*_{}\\[\\]()#.!+\\->]?+   # Escapes
+                  | \\[
+                  (
+                          (?<square>                    # Named group
+                        [^\\[\\]\\\\]                   # Match most chars
+                            | \\\\.                     # Escaped chars
+                            | \\[ \\g<square>*+ \\]     # Nested brackets
+                          )*+
+                    \\]
+                    (
+                      (                                 # Reference Link
+                        [ ]?                            # Optional space
+                        \\[[^\\]]*+\\]                  # Ref name
+                      )
+                      | (                               # Inline Link
+                        \\(                             # Opening paren
+                          [ \\t]*+                      # Optional whtiespace
+                          <?(.*?)>?                     # URL
+                          [ \\t]*+                      # Optional whtiespace
+                          (                             # Optional Title
+                            (?<title>[\'"])
+                            (.*?)
+                            \\k<title>
+                          )?
+                        \\)
+                      )
+                    )
+                  )
+                  | \\1\\1                              # Must be bold closer
+                  | (?!(?<=\\S)\\1).                    # Everything besides
+                                                        # style closer
+                )++
+                (?<=\\S)\\1                             # Close
+              )
+            '
     'captures':
       '1':
         'name': 'punctuation.definition.italic.markdown'
@@ -484,7 +624,20 @@
         'name': 'punctuation.definition.string.end.markdown'
       '16':
         'name': 'punctuation.definition.metadata.markdown'
-    'match': '(?x:\n\t\t\t\t(\\[)((?<square>[^\\[\\]\\\\]|\\\\.|\\[\\g<square>*+\\])*+)(\\])\n\t\t\t\t\t\t\t\t\t\t\t# Match the link text.\n\t\t\t\t([ ])?\t\t\t\t\t\t# Space not allowed\n\t\t\t\t(\\()\t\t\t\t\t\t# Opening paren for url\n\t\t\t\t\t(<?)(.*?)(>?)\t\t\t# The url\n\t\t\t\t\t[ \\t]*\t\t\t\t\t# Optional whitespace\n\t\t\t\t\t(?:\n\t\t\t\t\t\t  ((\\().+?(\\)))\t\t# Match title in parens…\n\t\t\t\t\t\t| ((").+?("))\t\t# or in quotes.\n\t\t\t\t\t)?\t\t\t\t\t\t# Title is optional\n\t\t\t\t\t\\s*\t\t\t\t\t\t# Optional whitespace\n\t\t\t\t(\\))\n\t\t\t )'
+    'match': '(?x:
+              (\\[)((?<square>[^\\[\\]\\\\]|\\\\.|\\[\\g<square>*+\\])*+)(\\])
+                                        # Match the link text.
+              ([ ])?                    # Space not allowed
+              (\\()                     # Opening paren for url
+                (<?)(.*?)(>?)           # The url
+                [ \\t]*                 # Optional whitespace
+                (?:
+                    ((\\().+?(\\)))     # Match title in parens…
+                  | ((").+?("))         # or in quotes.
+                )?                      # Title is optional
+                \\s*                    # Optional whitespace
+              (\\))
+             )'
     'name': 'meta.link.inline.markdown'
   'link-ref':
     'captures':


### PR DESCRIPTION
Instead of removing `\n` and `\t`, I have replaced them with new lines and 2 spaces. This makes it easier to read and matches the original tmbundle format.