### PR TITLE
Encase extended regexes in triple quotes

### DIFF
--- a/grammars/coffeescript (literate).cson
+++ b/grammars/coffeescript (literate).cson
@@ -4,23 +4,12 @@
   'litcoffee.erb'
   'coffee.md'
 ]
-'foldingStartMarker': '(?x)
-                       (<(?i:head|body|table|thead|tbody|tfoot|tr|div|select|fieldset|style|script|ul|ol|form|dl)\\b.*?>
-                       |<!--(?!.*-->)
-                       |\\{\\s*($|\\?>\\s*$|//|/\\*(.*\\*/\\s*$|(?!.*?\\*/)))
-                       )'
-'foldingStopMarker': '(?x)
-                      (</(?i:head|body|table|thead|tbody|tfoot|tr|div|select|fieldset|style|script|ul|ol|form|dl)>
-                      |^\\s*-->
-                      |(^|\\s)\\}
-                      )'
 'name': 'CoffeeScript (Literate)'
+'scopeName': 'source.litcoffee'
 'patterns': [
   {
-    'begin': '(?x)^
-              (?=  ([ ]{4}|\\t)(?!$))'
-    'end': '(?x)^
-            (?!  ([ ]{4}|\\t))'
+    'begin': '^(?=([ ]{4}|\\t)(?!$))'
+    'end': '^(?!([ ]{4}|\\t))'
     'name': 'markup.raw.block.markdown'
     'patterns': [
       {
@@ -29,17 +18,21 @@
     ]
   }
   {
-    'begin': '(?x)^
+    'begin': '''
+              (?x)^
               (?=  [ ]{0,3}>.
               |  [#]{1,6}\\s*+
               |  [ ]{0,3}(?<marker>[-*_])([ ]{0,2}\\k<marker>){2,}[ \\t]*+$
-              )'
+              )
+            '''
     'comment': 'We could also use an empty end match and set applyEndPatternLast, but then we must be sure that the begin pattern will only match stuff matched by the sub-patterns.'
-    'end': '(?x)^
+    'end': '''
+            (?x)^
             (?!  [ ]{0,3}>.
             |  [#]{1,6}\\s*+
             |  [ ]{0,3}(?<marker>[-*_])([ ]{0,2}\\k<marker>){2,}[ \\t]*+$
-            )'
+            )
+          '''
     'name': 'meta.block-level.markdown'
     'patterns': [
       {
@@ -129,19 +122,20 @@
         'name': 'punctuation.definition.string.begin.markdown'
       '13':
         'name': 'punctuation.definition.string.end.markdown'
-    'match': '(?x:
-                \\s*                    # Leading whitespace
-                (\\[)(.+?)(\\])(:)      # Reference name
-                [ \\t]*                 # Optional whitespace
-                (<?)(\\S+?)(>?)         # The url
-                [ \\t]*                 # Optional whitespace
-                (?:
-                    ((\\().+?(\\)))     # Match title in quotes…
-                  | ((").+?("))         # or in parens.
-                )?                      # Title is optional
-                \\s*                    # Optional whitespace
-                $
-              )'
+    'match': '''
+              (?x)
+              \\s*                    # Leading whitespace
+              (\\[)(.+?)(\\])(:)      # Reference name
+              [ \\t]*                 # Optional whitespace
+              (<?)(\\S+?)(>?)         # The url
+              [ \\t]*                 # Optional whitespace
+              (?:
+                ((\\().+?(\\)))       # Match title in quotes…
+                | ((").+?("))         # or in parens.
+              )?                      # Title is optional
+              \\s*                    # Optional whitespace
+              $
+            '''
     'name': 'meta.link.reference.def.markdown'
   }
   {
@@ -183,17 +177,21 @@
       '1':
         'name': 'punctuation.definition.blockquote.markdown'
     'comment': ' We terminate the block quote when seeing an empty line, a separator or a line with leading > characters. The latter is to “reset” the quote level for quoted lines.'
-    'end': '(?x)^
+    'end': '''
+            (?x)^
             (?=  \\s*$
             |  [ ]{0,3}(?<marker>[-*_])([ ]{0,2}\\k<marker>){2,}[ \\t]*+$
             |  [ ]{0,3}>.
-            )'
+            )
+          '''
     'name': 'markup.quote.markdown'
     'patterns': [
       {
-        'begin': '(?x)\\G
+        'begin': '''
+                  (?x)\\G
                   (?=  [ ]{0,3}>.
-                  )'
+                  )
+                '''
         'end': '^'
         'patterns': [
           {
@@ -203,11 +201,13 @@
       }
       {
         'applyEndPatternLast': 1
-        'begin': '(?x)\\G
+        'begin': '''
+                  (?x)\\G
                   (?=  ([ ]{4}|\\t)
                   |  [#]{1,6}\\s*+
                   |  [ ]{0,3}(?<marker>[-*_])([ ]{0,2}\\k<marker>){2,}[ \\t]*+$
-                  )'
+                  )
+                '''
         'end': '^'
         'patterns': [
           {
@@ -222,13 +222,15 @@
         ]
       }
       {
-        'begin': '(?x)\\G
+        'begin': '''
+                  (?x)\\G
                   (?!  $
                   |  [ ]{0,3}>.
                   |  ([ ]{4}|\\t)
                   |  [#]{1,6}\\s*+
                   |  [ ]{0,3}(?<marker>[-*_])([ ]{0,2}\\k<marker>){2,}[ \\t]*+$
-                  )'
+                  )
+                '''
         'end': '$|(?<=\\n)'
         'patterns': [
           {
@@ -245,46 +247,47 @@
       }
     ]
   'bold':
-    'begin': '(?x)
+    'begin': '''
+              (?x)
               (\\*\\*|__)(?=\\S)                                          # Open
               (?=
                 (
-                    <[^>]*+>                                              # HTML tags
+                  <[^>]*+>                                                # HTML tags
                   | (?<raw>`+)([^`]|(?!(?<!`)\\k<raw>(?!`))`)*+\\k<raw>   # Raw
                   | \\\\[\\\\`*_{}\\[\\]()#.!+\\->]?+                     # Escapes
                   | \\[
                   (
-                          (?<square>                                      # Named group
-                        [^\\[\\]\\\\]                                     # Match most chars
-                            | \\\\.                                       # Escaped chars
-                            | \\[ \\g<square>*+ \\]                       # Nested brackets
-                          )*+
+                    (?<square>                                            # Named group
+                      [^\\[\\]\\\\]                                       # Match most chars
+                      | \\\\.                                             # Escaped chars
+                      | \\[ \\g<square>*+ \\]                             # Nested brackets
+                    )*+
                     \\]
                     (
                       (                                                   # Reference Link
                         [ ]?                                              # Optional space
                         \\[[^\\]]*+\\]                                    # Ref name
                       )
-                      | (                                                 # Inline Link
+                      |
+                      (                                                   # Inline Link
                         \\(                                               # Opening paren
-                          [ \\t]*+                                        # Optional whtiespace
-                          <?(.*?)>?                                       # URL
-                          [ \\t]*+                                        # Optional whtiespace
-                          (                                               # Optional Title
-                            (?<title>[\'"])
-                            (.*?)
-                            \\k<title>
-                          )?
+                        [ \\t]*+                                          # Optional whitespace
+                        <?(.*?)>?                                         # URL
+                        [ \\t]*+                                          # Optional whitespace
+                        (                                                 # Optional Title
+                          (?<title>[\'"])
+                          (.*?)
+                          \\k<title>
+                        )?
                         \\)
                       )
                     )
                   )
                   | (?!(?<=\\S)\\1).                                      # Everything besides
-                                                                          # style closer
                 )++
                 (?<=\\S)\\1                                               # Close
               )
-            '
+            '''
     'captures':
       '1':
         'name': 'punctuation.definition.bold.markdown'
@@ -396,21 +399,21 @@
         'name': 'punctuation.definition.string.markdown'
       '16':
         'name': 'punctuation.definition.metadata.markdown'
-    'match': '(?x:
+    'match': '''
+              (?x)
               \\!                       # Images start with !
-              (\\[)((?<square>[^\\[\\]\\\\]|\\\\.|\\[\\g<square>*+\\])*+)(\\])
-                                        # Match the link text.
+              (\\[)((?<square>[^\\[\\]\\\\]|\\\\.|\\[\\g<square>*+\\])*+)(\\]) # Match the link text
               ([ ])?                    # Space not allowed
               (\\()                     # Opening paren for url
-                (<?)(\\S+?)(>?)         # The url
-                [ \\t]*                 # Optional whitespace
-                (?:
-                    ((\\().+?(\\)))     # Match title in parens…
-                  | ((").+?("))         # or in quotes.
-                )?                      # Title is optional
-                \\s*                    # Optional whitespace
+              (<?)(\\S+?)(>?)           # The url
+              [ \\t]*                   # Optional whitespace
+              (?:
+                ((\\().+?(\\)))         # Match title in parens…
+                | ((").+?("))           # or in quotes.
+              )?                        # Title is optional
+              \\s*                      # Optional whitespace
               (\\))
-             )'
+            '''
     'name': 'meta.image.inline.markdown'
   'image-ref':
     'captures':
@@ -474,48 +477,48 @@
       }
     ]
   'italic':
-    'begin': '(?x)
-              (\\*|_)(?=\\S)                            # Open
+    'begin': '''
+              (?x)
+              (\\*|_)(?=\\S)                                            # Open
               (?=
                 (
-                    <[^>]*+>                            # HTML tags
-                  | (?<raw>`+)([^`]|(?!(?<!`)\\k<raw>(?!`))`)*+\\k<raw>
-                                    # Raw
-                  | \\\\[\\\\`*_{}\\[\\]()#.!+\\->]?+   # Escapes
+                  <[^>]*+>                                              # HTML tags
+                  | (?<raw>`+)([^`]|(?!(?<!`)\\k<raw>(?!`))`)*+\\k<raw> # Raw
+                  | \\\\[\\\\`*_{}\\[\\]()#.!+\\->]?+                   # Escapes
                   | \\[
                   (
-                          (?<square>                    # Named group
-                        [^\\[\\]\\\\]                   # Match most chars
-                            | \\\\.                     # Escaped chars
-                            | \\[ \\g<square>*+ \\]     # Nested brackets
-                          )*+
+                    (?<square>                                          # Named group
+                      [^\\[\\]\\\\]                                     # Match most chars
+                      | \\\\.                                           # Escaped chars
+                      | \\[ \\g<square>*+ \\]                           # Nested brackets
+                    )*+
                     \\]
                     (
-                      (                                 # Reference Link
-                        [ ]?                            # Optional space
-                        \\[[^\\]]*+\\]                  # Ref name
+                      (                                                 # Reference Link
+                        [ ]?                                            # Optional space
+                        \\[[^\\]]*+\\]                                  # Ref name
                       )
-                      | (                               # Inline Link
-                        \\(                             # Opening paren
-                          [ \\t]*+                      # Optional whtiespace
-                          <?(.*?)>?                     # URL
-                          [ \\t]*+                      # Optional whtiespace
-                          (                             # Optional Title
-                            (?<title>[\'"])
-                            (.*?)
-                            \\k<title>
-                          )?
+                      |
+                      (                                                 # Inline Link
+                        \\(                                             # Opening paren
+                        [ \\t]*+                                        # Optional whitespace
+                        <?(.*?)>?                                       # URL
+                        [ \\t]*+                                        # Optional whitespace
+                        (                                               # Optional Title
+                          (?<title>[\'"])
+                          (.*?)
+                          \\k<title>
+                        )?
                         \\)
                       )
                     )
                   )
-                  | \\1\\1                              # Must be bold closer
-                  | (?!(?<=\\S)\\1).                    # Everything besides
-                                                        # style closer
+                  | \\1\\1                                               # Must be bold closer
+                  | (?!(?<=\\S)\\1).                                     # Everything besides
                 )++
-                (?<=\\S)\\1                             # Close
+                (?<=\\S)\\1                                              # Close
               )
-            '
+            '''
     'captures':
       '1':
         'name': 'punctuation.definition.italic.markdown'
@@ -624,20 +627,20 @@
         'name': 'punctuation.definition.string.end.markdown'
       '16':
         'name': 'punctuation.definition.metadata.markdown'
-    'match': '(?x:
-              (\\[)((?<square>[^\\[\\]\\\\]|\\\\.|\\[\\g<square>*+\\])*+)(\\])
-                                        # Match the link text.
-              ([ ])?                    # Space not allowed
-              (\\()                     # Opening paren for url
-                (<?)(.*?)(>?)           # The url
-                [ \\t]*                 # Optional whitespace
-                (?:
-                    ((\\().+?(\\)))     # Match title in parens…
-                  | ((").+?("))         # or in quotes.
-                )?                      # Title is optional
-                \\s*                    # Optional whitespace
+    'match': '''
+              (?x)
+              (\\[)((?<square>[^\\[\\]\\\\]|\\\\.|\\[\\g<square>*+\\])*+)(\\]) # Match the link text.
+              ([ ])?            # Space not allowed
+              (\\()             # Opening paren for url
+              (<?)(.*?)(>?)     # The url
+              [ \\t]*           # Optional whitespace
+              (?:
+                ((\\().+?(\\))) # Match title in parens…
+                | ((").+?("))   # or in quotes.
+              )?                # Title is optional
+              \\s*              # Optional whitespace
               (\\))
-             )'
+            '''
     'name': 'meta.link.inline.markdown'
   'link-ref':
     'captures':
@@ -700,4 +703,3 @@
   'separator':
     'match': '\\G[ ]{0,3}([-*_])([ ]{0,2}\\1){2,}[ \\t]*$\\n?'
     'name': 'meta.separator.markdown'
-'scopeName': 'source.litcoffee'

--- a/spec/coffee-script-literate-spec.coffee
+++ b/spec/coffee-script-literate-spec.coffee
@@ -1,4 +1,4 @@
-describe "CoffeeScript grammar", ->
+describe "CoffeeScript (Literate) grammar", ->
   grammar = null
 
   beforeEach ->

--- a/spec/coffee-script-literate-spec.coffee
+++ b/spec/coffee-script-literate-spec.coffee
@@ -1,0 +1,13 @@
+describe "CoffeeScript grammar", ->
+  grammar = null
+
+  beforeEach ->
+    waitsForPromise ->
+      atom.packages.activatePackage("language-coffee-script")
+
+    runs ->
+      grammar = atom.grammars.grammarForScopeName("source.litcoffee")
+
+  it "parses the grammar", ->
+    expect(grammar).toBeTruthy()
+    expect(grammar.scopeName).toBe "source.litcoffee"


### PR DESCRIPTION
Fixes #71

Also took the liberty of reformatting some of them and removing the useless folding markers.

A skeleton `coffee-script-literate-spec.coffee` has been added to prevent this from happening in the future.

/cc @adrianlee44 

@davibe, @B34rPG: if you two could clone this branch and then `apm link` it to see if it fixes your issue, that would be fantastic.