### PR TITLE
Fix for Issue #75

### DIFF
--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -229,7 +229,7 @@
     'name': 'meta.function.coffee'
   }
   {
-    'match': '@?\\b(?!class|subclass|extends|decodeURI(Component)?|encodeURI(Component)?|eval|parse(Float|Int)|require)\\w+(\\s+(?!(of|in|then|is|isnt|and|or|for|else|when|not|if)\\s)(?=(\\w+|\\->|\\-\\d|\\[|\\{|\"|\'))|(?=\\())'
+    'match': '@?\\b(?!class|subclass|extends|decodeURI(Component)?|encodeURI(Component)?|eval|parse(Float|Int)|require)\\w+(\\s+(?!(of|in|then|is|isnt|and|or|for|else|when|not|if)\\s)(?=(\\@?\\w+|\\->|\\-\\d|\\[|\\{|\"|\'))|(?=\\())'
     'name': 'entity.name.function.coffee'
   }
   {

--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -229,7 +229,7 @@
     'name': 'meta.function.coffee'
   }
   {
-    'match': '@?\\b(?!class|subclass|extends|decodeURI(Component)?|encodeURI(Component)?|eval|parse(Float|Int)|require)\\w+(\\s+(?!(of|in|then|is|isnt|and|or|for|else|when|not|if)\\s)(?=(\\@?\\w+|\\->|\\-\\d|\\[|\\{|\"|\'))|(?=\\())'
+    'match': '@?\\b(?!class|subclass|extends|decodeURI(Component)?|encodeURI(Component)?|eval|parse(Float|Int)|require)\\w+(\\s+(?!(of|in|then|is|isnt|and|or|for|else|when|not|if)\\s)(?=(@?\\w+|\\->|\\-\\d|\\[|\\{|\"|\'))|(?=\\())'
     'name': 'entity.name.function.coffee'
   }
   {

--- a/spec/coffee-script-spec.coffee
+++ b/spec/coffee-script-spec.coffee
@@ -284,7 +284,11 @@ describe "CoffeeScript grammar", ->
     expect(tokens[4]).toEqual value: "in", scopes: ["source.coffee", "keyword.control.coffee"]
     expect(tokens[5]).toEqual value: " foods", scopes: ["source.coffee"]
 
-  it "properly tokenizes paren-less function calls whose first arg is an instance variable", ->
     {tokens} = grammar.tokenizeLine("foo @bar")
     expect(tokens[0]).toEqual value: "foo ", scopes: ["source.coffee", "entity.name.function.coffee"]
     expect(tokens[1]).toEqual value: "@bar", scopes: ["source.coffee", "variable.other.readwrite.instance.coffee"]
+
+    {tokens} = grammar.tokenizeLine("foo baz, @bar")
+    expect(tokens[0]).toEqual value: "foo ", scopes: ["source.coffee", "entity.name.function.coffee"]
+    expect(tokens[1]).toEqual value: "baz", scopes: ["source.coffee"]
+    expect(tokens[3]).toEqual value: "@bar", scopes: ["source.coffee", "variable.other.readwrite.instance.coffee"]

--- a/spec/coffee-script-spec.coffee
+++ b/spec/coffee-script-spec.coffee
@@ -283,3 +283,8 @@ describe "CoffeeScript grammar", ->
     expect(tokens[3]).toEqual value: " food ", scopes: ["source.coffee"]
     expect(tokens[4]).toEqual value: "in", scopes: ["source.coffee", "keyword.control.coffee"]
     expect(tokens[5]).toEqual value: " foods", scopes: ["source.coffee"]
+
+  it "properly tokenizes paren-less function calls whose first arg is an instance variable", ->
+    {tokens} = grammar.tokenizeLine("foo @bar")
+    expect(tokens[0]).toEqual value: "foo ", scopes: ["source.coffee", "entity.name.function.coffee"]
+    expect(tokens[1]).toEqual value: "@bar", scopes: ["source.coffee", "variable.other.readwrite.instance.coffee"]


### PR DESCRIPTION
An attempt at fixing #75

New specs pass and no known regressions, but could use review, since I’m not familiar with these grammar files. 

Thanks for the pointer on running the specs. Is there a way I can symlink my copy of the library with Atom just to see the syntax highlighting in action?