### PR TITLE
Correct some incorrect scopes

### DIFF
--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -149,7 +149,7 @@
     'name': 'keyword.reserved.coffee'
   }
   {
-    'match': '([a-zA-Z$_][a-zA-Z0-9$_]*)\\s*(?!::)(?:(:)|((?:or|and|[-+\\/&%*?])?=)(?![>=]))(?!(\\s*\\(.*\\))?\\s*([=-]>))'
+    'match': '([a-zA-Z$_][\\w$]*)\\s*(?!::)(?:(:)|((?:or|and|[-+\\/&%*?])?=)(?![>=]))(?!(\\s*\\(.*\\))?\\s*([=-]>))'
     'captures':
       '1':
         'name': 'variable.assignment.coffee'
@@ -239,7 +239,7 @@
     'name': 'constant.language.boolean.false.coffee'
   }
   {
-    'match': '@?\\b(?!class|subclass|extends|decodeURI(Component)?|encodeURI(Component)?|eval|parse(Float|Int)|require)(\\w+)(?:\\s+(?!(of|in|then|is|isnt|and|or|for|else|when|not|if)\\b)(?=(@?\\w+|\\->|\\-\\d|\\[|\\{|\"|\'))|(?=\\())'
+    'match': '@?\\b(?!class|subclass|extends|decodeURI(Component)?|encodeURI(Component)?|eval|parse(Float|Int)|require)(\\w+)(?=\\s+(?!(of|in|then|is|isnt|and|or|for|else|when|not|if)\\b)(?=(@?\\w+|\\->|\\-\\d|\\[|\\{|\"|\'))|(?=\\())'
     'captures':
       '4':
         'name': 'entity.name.function.coffee'
@@ -337,7 +337,7 @@
     'name': 'punctuation.terminator.statement.coffee'
   }
   {
-    'match': ',[ |\\t]*'
+    'match': ','
     'name': 'meta.delimiter.object.comma.coffee'
   }
   {

--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -8,8 +8,6 @@
   '_coffee'
 ]
 'firstLineMatch': '^#!.*\\bcoffee'
-'foldingStartMarker': '^\\s*class\\s+\\S.*$|.*(->|=>)\\s*$|.*[\\[{]\\s*$'
-'foldingStopMarker': '^\\s*$|^\\s*[}\\]]\\s*$'
 'patterns': [
   {
     'captures':
@@ -151,15 +149,14 @@
     'name': 'keyword.reserved.coffee'
   }
   {
+    'match': '([a-zA-Z$_][a-zA-Z0-9$_]*)\\s*(?!::)(?:(:)|((?:or|and|[-+\\/&%*?])?=)(?![>=]))(?!(\\s*\\(.*\\))?\\s*([=-]>))'
     'captures':
       '1':
         'name': 'variable.assignment.coffee'
-      '4':
+      '2':
         'name': 'punctuation.separator.key-value'
-      '5':
+      '3':
         'name': 'keyword.operator.coffee'
-    'match': '([a-zA-Z\\$_](\\w|\\$|\\.)*\\s*(?!\\::)((:)|((?:or|and|[-+/&%*?])?=)(?![>=]))(?!(\\s*\\(.*\\))?\\s*([=-]>)))'
-    'name': 'variable.assignment.coffee'
   }
   {
     'begin': '(?<=\\s|^)(\\{)(?=.+?\\}\\s+[:=])'
@@ -218,6 +215,12 @@
     ]
   }
   {
+    'match': '''(?x)
+                (?<=^|\\s)
+                (?=@?[a-zA-Z\\$_])
+                @?([a-zA-Z\\$_]\\w*)(\\$|:|\\.)?\\s*
+                (?=[:=](\\s*\\(.*\\))?\\s*([=-]>))
+              '''
     'captures':
       '1':
         'name': 'entity.name.function.coffee'
@@ -225,7 +228,6 @@
         'name': 'variable.parameter.function.coffee'
       '4':
         'name': 'storage.type.function.coffee'
-    'match': '(?<=^|\\s)(?=@?[a-zA-Z\\$_])(@?[a-zA-Z\\$_](\\w|\\$|:|\\.)*\\s*(?=[:=](\\s*\\(.*\\))?\\s*([=-]>)))'
     'name': 'meta.function.coffee'
   }
   {
@@ -237,8 +239,10 @@
     'name': 'constant.language.boolean.false.coffee'
   }
   {
-    'match': '@?\\b(?!class|subclass|extends|decodeURI(Component)?|encodeURI(Component)?|eval|parse(Float|Int)|require)\\w+(\\s+(?!(of|in|then|is|isnt|and|or|for|else|when|not|if)\\s)(?=(@?\\w+|\\->|\\-\\d|\\[|\\{|\"|\'))|(?=\\())'
-    'name': 'entity.name.function.coffee'
+    'match': '@?\\b(?!class|subclass|extends|decodeURI(Component)?|encodeURI(Component)?|eval|parse(Float|Int)|require)(\\w+)(?:\\s+(?!(of|in|then|is|isnt|and|or|for|else|when|not|if)\\b)(?=(@?\\w+|\\->|\\-\\d|\\[|\\{|\"|\'))|(?=\\())'
+    'captures':
+      '4':
+        'name': 'entity.name.function.coffee'
   }
   {
     'match': '[=-]>'

--- a/spec/coffee-script-spec.coffee
+++ b/spec/coffee-script-spec.coffee
@@ -99,55 +99,55 @@ describe "CoffeeScript grammar", ->
     expect(tokens[0]).toEqual value: "this", scopes: ["source.coffee", "variable.language.this.coffee"]
 
   it "tokenizes variable assignments", ->
-    {tokens} = grammar.tokenizeLine("a = b")
-    expect(tokens[0]).toEqual value: "a ", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee"]
-    expect(tokens[1]).toEqual value: "=", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee", "keyword.operator.coffee"]
-    expect(tokens[2]).toEqual value: " b", scopes: ["source.coffee"]
+    {tokens} = grammar.tokenizeLine("something = b")
+    expect(tokens[0]).toEqual value: "something", scopes: ["source.coffee", "variable.assignment.coffee"]
+    expect(tokens[2]).toEqual value: "=", scopes: ["source.coffee", "keyword.operator.coffee"]
+    expect(tokens[3]).toEqual value: " b", scopes: ["source.coffee"]
 
     {tokens} = grammar.tokenizeLine("a and= b")
-    expect(tokens[0]).toEqual value: "a ", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee"]
-    expect(tokens[1]).toEqual value: "and=", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee", "keyword.operator.coffee"]
-    expect(tokens[2]).toEqual value: " b", scopes: ["source.coffee"]
+    expect(tokens[0]).toEqual value: "a", scopes: ["source.coffee", "variable.assignment.coffee"]
+    expect(tokens[2]).toEqual value: "and=", scopes: ["source.coffee", "keyword.operator.coffee"]
+    expect(tokens[3]).toEqual value: " b", scopes: ["source.coffee"]
 
     {tokens} = grammar.tokenizeLine("a or= b")
-    expect(tokens[0]).toEqual value: "a ", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee"]
-    expect(tokens[1]).toEqual value: "or=", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee", "keyword.operator.coffee"]
-    expect(tokens[2]).toEqual value: " b", scopes: ["source.coffee"]
+    expect(tokens[0]).toEqual value: "a", scopes: ["source.coffee", "variable.assignment.coffee"]
+    expect(tokens[2]).toEqual value: "or=", scopes: ["source.coffee", "keyword.operator.coffee"]
+    expect(tokens[3]).toEqual value: " b", scopes: ["source.coffee"]
 
     {tokens} = grammar.tokenizeLine("a -= b")
-    expect(tokens[0]).toEqual value: "a ", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee"]
-    expect(tokens[1]).toEqual value: "-=", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee", "keyword.operator.coffee"]
-    expect(tokens[2]).toEqual value: " b", scopes: ["source.coffee"]
+    expect(tokens[0]).toEqual value: "a", scopes: ["source.coffee", "variable.assignment.coffee"]
+    expect(tokens[2]).toEqual value: "-=", scopes: ["source.coffee", "keyword.operator.coffee"]
+    expect(tokens[3]).toEqual value: " b", scopes: ["source.coffee"]
 
     {tokens} = grammar.tokenizeLine("a += b")
-    expect(tokens[0]).toEqual value: "a ", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee"]
-    expect(tokens[1]).toEqual value: "+=", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee", "keyword.operator.coffee"]
-    expect(tokens[2]).toEqual value: " b", scopes: ["source.coffee"]
+    expect(tokens[0]).toEqual value: "a", scopes: ["source.coffee", "variable.assignment.coffee"]
+    expect(tokens[2]).toEqual value: "+=", scopes: ["source.coffee", "keyword.operator.coffee"]
+    expect(tokens[3]).toEqual value: " b", scopes: ["source.coffee"]
 
     {tokens} = grammar.tokenizeLine("a /= b")
-    expect(tokens[0]).toEqual value: "a ", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee"]
-    expect(tokens[1]).toEqual value: "/=", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee", "keyword.operator.coffee"]
-    expect(tokens[2]).toEqual value: " b", scopes: ["source.coffee"]
+    expect(tokens[0]).toEqual value: "a", scopes: ["source.coffee", "variable.assignment.coffee"]
+    expect(tokens[2]).toEqual value: "/=", scopes: ["source.coffee", "keyword.operator.coffee"]
+    expect(tokens[3]).toEqual value: " b", scopes: ["source.coffee"]
 
     {tokens} = grammar.tokenizeLine("a &= b")
-    expect(tokens[0]).toEqual value: "a ", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee"]
-    expect(tokens[1]).toEqual value: "&=", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee", "keyword.operator.coffee"]
-    expect(tokens[2]).toEqual value: " b", scopes: ["source.coffee"]
+    expect(tokens[0]).toEqual value: "a", scopes: ["source.coffee", "variable.assignment.coffee"]
+    expect(tokens[2]).toEqual value: "&=", scopes: ["source.coffee", "keyword.operator.coffee"]
+    expect(tokens[3]).toEqual value: " b", scopes: ["source.coffee"]
 
     {tokens} = grammar.tokenizeLine("a %= b")
-    expect(tokens[0]).toEqual value: "a ", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee"]
-    expect(tokens[1]).toEqual value: "%=", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee", "keyword.operator.coffee"]
-    expect(tokens[2]).toEqual value: " b", scopes: ["source.coffee"]
+    expect(tokens[0]).toEqual value: "a", scopes: ["source.coffee", "variable.assignment.coffee"]
+    expect(tokens[2]).toEqual value: "%=", scopes: ["source.coffee", "keyword.operator.coffee"]
+    expect(tokens[3]).toEqual value: " b", scopes: ["source.coffee"]
 
     {tokens} = grammar.tokenizeLine("a *= b")
-    expect(tokens[0]).toEqual value: "a ", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee"]
-    expect(tokens[1]).toEqual value: "*=", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee", "keyword.operator.coffee"]
-    expect(tokens[2]).toEqual value: " b", scopes: ["source.coffee"]
+    expect(tokens[0]).toEqual value: "a", scopes: ["source.coffee", "variable.assignment.coffee"]
+    expect(tokens[2]).toEqual value: "*=", scopes: ["source.coffee", "keyword.operator.coffee"]
+    expect(tokens[3]).toEqual value: " b", scopes: ["source.coffee"]
 
     {tokens} = grammar.tokenizeLine("a ?= b")
-    expect(tokens[0]).toEqual value: "a ", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee"]
-    expect(tokens[1]).toEqual value: "?=", scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee", "keyword.operator.coffee"]
-    expect(tokens[2]).toEqual value: " b", scopes: ["source.coffee"]
+    expect(tokens[0]).toEqual value: "a", scopes: ["source.coffee", "variable.assignment.coffee"]
+    expect(tokens[2]).toEqual value: "?=", scopes: ["source.coffee", "keyword.operator.coffee"]
+    expect(tokens[3]).toEqual value: " b", scopes: ["source.coffee"]
 
     {tokens} = grammar.tokenizeLine("a == b")
     expect(tokens[0]).toEqual value: "a ", scopes: ["source.coffee"]
@@ -267,31 +267,32 @@ describe "CoffeeScript grammar", ->
       """
     expect(lines[0][0]).toEqual value: '`', scopes: ["source.coffee", "string.quoted.script.coffee", "punctuation.definition.string.begin.coffee"]
     expect(lines[0][1]).toEqual value: 'v', scopes: ["source.coffee", "string.quoted.script.coffee", "constant.character.escape.coffee"]
-    expect(lines[1][0]).toEqual value: 'a ', scopes: ["source.coffee", "variable.assignment.coffee", "variable.assignment.coffee"]
+    expect(lines[1][0]).toEqual value: 'a', scopes: ["source.coffee", "variable.assignment.coffee"]
 
   it "tokenizes functions", ->
     {tokens} = grammar.tokenizeLine("foo = -> 1")
-    expect(tokens[0]).toEqual value: "foo ", scopes: ["source.coffee", "meta.function.coffee", "entity.name.function.coffee"]
+    expect(tokens[0]).toEqual value: "foo", scopes: ["source.coffee", "meta.function.coffee", "entity.name.function.coffee"]
 
     {tokens} = grammar.tokenizeLine("foo bar")
-    expect(tokens[0]).toEqual value: "foo ", scopes: ["source.coffee", "entity.name.function.coffee"]
+    expect(tokens[0]).toEqual value: "foo", scopes: ["source.coffee", "entity.name.function.coffee"]
 
     {tokens} = grammar.tokenizeLine("eat food for food in foods")
-    expect(tokens[0]).toEqual value: "eat ", scopes: ["source.coffee", "entity.name.function.coffee"]
-    expect(tokens[1]).toEqual value: "food ", scopes: ["source.coffee"]
-    expect(tokens[2]).toEqual value: "for", scopes: ["source.coffee", "keyword.control.coffee"]
-    expect(tokens[3]).toEqual value: " food ", scopes: ["source.coffee"]
-    expect(tokens[4]).toEqual value: "in", scopes: ["source.coffee", "keyword.control.coffee"]
-    expect(tokens[5]).toEqual value: " foods", scopes: ["source.coffee"]
+    expect(tokens[0]).toEqual value: "eat", scopes: ["source.coffee", "entity.name.function.coffee"]
+    expect(tokens[1]).toEqual value: " ", scopes: ["source.coffee"]
+    expect(tokens[2]).toEqual value: "food ", scopes: ["source.coffee"]
+    expect(tokens[3]).toEqual value: "for", scopes: ["source.coffee", "keyword.control.coffee"]
+    expect(tokens[4]).toEqual value: " food ", scopes: ["source.coffee"]
+    expect(tokens[5]).toEqual value: "in", scopes: ["source.coffee", "keyword.control.coffee"]
+    expect(tokens[6]).toEqual value: " foods", scopes: ["source.coffee"]
 
     {tokens} = grammar.tokenizeLine("foo @bar")
-    expect(tokens[0]).toEqual value: "foo ", scopes: ["source.coffee", "entity.name.function.coffee"]
-    expect(tokens[1]).toEqual value: "@bar", scopes: ["source.coffee", "variable.other.readwrite.instance.coffee"]
+    expect(tokens[0]).toEqual value: "foo", scopes: ["source.coffee", "entity.name.function.coffee"]
+    expect(tokens[2]).toEqual value: "@bar", scopes: ["source.coffee", "variable.other.readwrite.instance.coffee"]
 
     {tokens} = grammar.tokenizeLine("foo baz, @bar")
-    expect(tokens[0]).toEqual value: "foo ", scopes: ["source.coffee", "entity.name.function.coffee"]
-    expect(tokens[1]).toEqual value: "baz", scopes: ["source.coffee"]
-    expect(tokens[3]).toEqual value: "@bar", scopes: ["source.coffee", "variable.other.readwrite.instance.coffee"]
+    expect(tokens[0]).toEqual value: "foo", scopes: ["source.coffee", "entity.name.function.coffee"]
+    expect(tokens[2]).toEqual value: "baz", scopes: ["source.coffee"]
+    expect(tokens[4]).toEqual value: "@bar", scopes: ["source.coffee", "variable.other.readwrite.instance.coffee"]
 
   it "does not tokenize booleans as functions", ->
     {tokens} = grammar.tokenizeLine("false unless true")

--- a/spec/coffee-script-spec.coffee
+++ b/spec/coffee-script-spec.coffee
@@ -278,12 +278,11 @@ describe "CoffeeScript grammar", ->
 
     {tokens} = grammar.tokenizeLine("eat food for food in foods")
     expect(tokens[0]).toEqual value: "eat", scopes: ["source.coffee", "entity.name.function.coffee"]
-    expect(tokens[1]).toEqual value: " ", scopes: ["source.coffee"]
-    expect(tokens[2]).toEqual value: "food ", scopes: ["source.coffee"]
-    expect(tokens[3]).toEqual value: "for", scopes: ["source.coffee", "keyword.control.coffee"]
-    expect(tokens[4]).toEqual value: " food ", scopes: ["source.coffee"]
-    expect(tokens[5]).toEqual value: "in", scopes: ["source.coffee", "keyword.control.coffee"]
-    expect(tokens[6]).toEqual value: " foods", scopes: ["source.coffee"]
+    expect(tokens[1]).toEqual value: " food ", scopes: ["source.coffee"]
+    expect(tokens[2]).toEqual value: "for", scopes: ["source.coffee", "keyword.control.coffee"]
+    expect(tokens[3]).toEqual value: " food ", scopes: ["source.coffee"]
+    expect(tokens[4]).toEqual value: "in", scopes: ["source.coffee", "keyword.control.coffee"]
+    expect(tokens[5]).toEqual value: " foods", scopes: ["source.coffee"]
 
     {tokens} = grammar.tokenizeLine("foo @bar")
     expect(tokens[0]).toEqual value: "foo", scopes: ["source.coffee", "entity.name.function.coffee"]
@@ -291,7 +290,8 @@ describe "CoffeeScript grammar", ->
 
     {tokens} = grammar.tokenizeLine("foo baz, @bar")
     expect(tokens[0]).toEqual value: "foo", scopes: ["source.coffee", "entity.name.function.coffee"]
-    expect(tokens[2]).toEqual value: "baz", scopes: ["source.coffee"]
+    expect(tokens[1]).toEqual value: " baz", scopes: ["source.coffee"]
+    expect(tokens[2]).toEqual value: ",", scopes: ["source.coffee", "meta.delimiter.object.comma.coffee"]
     expect(tokens[4]).toEqual value: "@bar", scopes: ["source.coffee", "variable.other.readwrite.instance.coffee"]
 
   it "does not tokenize booleans as functions", ->


### PR DESCRIPTION
This is basically the same as #65, except I've fixed a very large mistake that the specs weren't catching.  I was accidentally only matching the first letter of a variable instead of the whole thing, which the specs didn't catch because they only tested one-character-long variables :/.

/cc @kevinsawicki 