### PR TITLE
Don't blindly eat tokens when trying to match destructuring assignments

### DIFF
--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -162,13 +162,15 @@
     'name': 'variable.assignment.coffee'
   }
   {
-    'begin': '(?<=\\s|^)(\\{)(?=.+?\\}\\s+[:=])'
+    'begin': '(?<=\\s|^)({)(?=[^\'"#]+?}\\s+=)'
     'beginCaptures':
-      '0':
-        'name': 'keyword.operator.coffee'
-    'end': '(\\}\\s*[:=])'
+      '1':
+        'name': 'punctuation.definition.destructuring.begin.bracket.curly.coffee'
+    'end': '(})\\s*(=)'
     'endCaptures':
-      '0':
+      '1':
+        'name': 'punctuation.definition.destructuring.end.bracket.curly.coffee'
+      '2':
         'name': 'keyword.operator.coffee'
     'name': 'meta.variable.assignment.destructured.object.coffee'
     'patterns': [
@@ -190,13 +192,15 @@
     ]
   }
   {
-    'begin': '(?<=\\s|^)(\\[)(?=.+?\\]\\s+[:=])'
+    'begin': '(?<=\\s|^)(\\[)(?=[^\'"#]+?\\]\\s+=)'
     'beginCaptures':
-      '0':
-        'name': 'keyword.operator.coffee'
-    'end': '(\\]\\s*[:=])'
+      '1':
+        'name': 'punctuation.definition.destructuring.begin.bracket.curly.coffee'
+    'end': '(\\])\\s*(=)'
     'endCaptures':
-      '0':
+      '1':
+        'name': 'punctuation.definition.destructuring.end.bracket.curly.coffee'
+      '2':
         'name': 'keyword.operator.coffee'
     'name': 'meta.variable.assignment.destructured.array.coffee'
     'patterns': [

--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -195,11 +195,11 @@
     'begin': '(?<=\\s|^)(\\[)(?=[^\'"#]+?\\]\\s+=)'
     'beginCaptures':
       '1':
-        'name': 'punctuation.definition.destructuring.begin.bracket.curly.coffee'
+        'name': 'punctuation.definition.destructuring.begin.bracket.square.coffee'
     'end': '(\\])\\s*(=)'
     'endCaptures':
       '1':
-        'name': 'punctuation.definition.destructuring.end.bracket.curly.coffee'
+        'name': 'punctuation.definition.destructuring.end.bracket.square.coffee'
       '2':
         'name': 'keyword.operator.coffee'
     'name': 'meta.variable.assignment.destructured.array.coffee'

--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -177,62 +177,40 @@
         'name': 'keyword.operator.coffee'
   }
   {
-    'begin': '(?<=\\s|^)({)(?=[^\'"#]+?}\\s+=)'
+    'begin': '(?<=\\s|^)({)(?=[^\'"#]+?}\\s*(\\]|}|=))'
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.destructuring.begin.bracket.curly.coffee'
-    'end': '(})\\s*(=)'
+    'end': '(})(?=\\s*(}|\\]|=))'
     'endCaptures':
       '1':
         'name': 'punctuation.definition.destructuring.end.bracket.curly.coffee'
-      '2':
-        'name': 'keyword.operator.coffee'
     'name': 'meta.variable.assignment.destructured.object.coffee'
     'patterns': [
       {
+        'include': '$self'
+      }
+      {
         'include': '#variable_name'
-      }
-      {
-        'include': '#instance_variable'
-      }
-      {
-        'include': '#single_quoted_string'
-      }
-      {
-        'include': '#double_quoted_string'
-      }
-      {
-        'include': '#numeric'
       }
     ]
   }
   {
-    'begin': '(?<=\\s|^)(\\[)(?=[^\'"#]+?\\]\\s+=)'
+    'begin': '(?<=\\s|^)(\\[)(?=[^\'"#]+?\\]\\s*(\\]|}|=))'
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.destructuring.begin.bracket.square.coffee'
-    'end': '(\\])\\s*(=)'
+    'end': '(\\])(?=\\s*(}|\\]|=))'
     'endCaptures':
       '1':
         'name': 'punctuation.definition.destructuring.end.bracket.square.coffee'
-      '2':
-        'name': 'keyword.operator.coffee'
     'name': 'meta.variable.assignment.destructured.array.coffee'
     'patterns': [
       {
+        'include': '$self'
+      }
+      {
         'include': '#variable_name'
-      }
-      {
-        'include': '#instance_variable'
-      }
-      {
-        'include': '#single_quoted_string'
-      }
-      {
-        'include': '#double_quoted_string'
-      }
-      {
-        'include': '#numeric'
       }
     ]
   }

--- a/spec/coffee-script-spec.coffee
+++ b/spec/coffee-script-spec.coffee
@@ -321,11 +321,23 @@ describe "CoffeeScript grammar", ->
     expect(tokens[0]).toEqual value: "{", scopes: ["source.coffee", "meta.variable.assignment.destructured.object.coffee", "punctuation.definition.destructuring.begin.bracket.curly.coffee"]
     expect(tokens[1]).toEqual value: "something", scopes: ["source.coffee", "meta.variable.assignment.destructured.object.coffee", "variable.assignment.coffee", "variable.assignment.coffee"]
     expect(tokens[2]).toEqual value: "}", scopes: ["source.coffee", "meta.variable.assignment.destructured.object.coffee", "punctuation.definition.destructuring.end.bracket.curly.coffee"]
-    expect(tokens[4]).toEqual value: "=", scopes: ["source.coffee", "meta.variable.assignment.destructured.object.coffee", "keyword.operator.coffee"]
+    expect(tokens[3]).toEqual value: " ", scopes: ["source.coffee"]
+    expect(tokens[4]).toEqual value: "=", scopes: ["source.coffee", "keyword.operator.coffee"]
     expect(tokens[5]).toEqual value: " hi", scopes: ["source.coffee"]
 
     {tokens} = grammar.tokenizeLine("{'} ='}") # Make sure this *isn't* tokenized as a destructuring assignment
     expect(tokens[0]).not.toEqual value: "{", scopes: ["source.coffee", "meta.variable.assignment.destructured.object.coffee", "punctuation.definition.destructuring.begin.bracket.curly.coffee"]
+
+  it "tokenizes nested destructuring assignments", ->
+    {tokens} = grammar.tokenizeLine("{poet: {name, address: [street, city]}} = futurists")
+    expect(tokens[0]).toEqual value: "{", scopes: ["source.coffee", "meta.variable.assignment.destructured.object.coffee", "punctuation.definition.destructuring.begin.bracket.curly.coffee"]
+    expect(tokens[4]).toEqual value: "{", scopes: ["source.coffee", "meta.variable.assignment.destructured.object.coffee", "meta.variable.assignment.destructured.object.coffee", "punctuation.definition.destructuring.begin.bracket.curly.coffee"]
+    expect(tokens[11]).toEqual value: "[", scopes: ["source.coffee", "meta.variable.assignment.destructured.object.coffee", "meta.variable.assignment.destructured.object.coffee", "meta.variable.assignment.destructured.array.coffee", "punctuation.definition.destructuring.begin.bracket.square.coffee"]
+    expect(tokens[16]).toEqual value: "]", scopes: ["source.coffee", "meta.variable.assignment.destructured.object.coffee", "meta.variable.assignment.destructured.object.coffee", "meta.variable.assignment.destructured.array.coffee", "punctuation.definition.destructuring.end.bracket.square.coffee"]
+    expect(tokens[17]).toEqual value: "}", scopes: ["source.coffee", "meta.variable.assignment.destructured.object.coffee", "meta.variable.assignment.destructured.object.coffee", "punctuation.definition.destructuring.end.bracket.curly.coffee"]
+    expect(tokens[18]).toEqual value: "}", scopes: ["source.coffee", "meta.variable.assignment.destructured.object.coffee", "punctuation.definition.destructuring.end.bracket.curly.coffee"]
+    expect(tokens[19]).toEqual value: " ", scopes: ["source.coffee"]
+    expect(tokens[20]).toEqual value: "=", scopes: ["source.coffee", "keyword.operator.coffee"]
 
   it "tokenizes inline constant followed by unless statement correctly", ->
     {tokens} = grammar.tokenizeLine("return 0 unless true")

--- a/spec/coffee-script-spec.coffee
+++ b/spec/coffee-script-spec.coffee
@@ -303,3 +303,14 @@ describe "CoffeeScript grammar", ->
     expect(tokens[0]).toEqual value: "true", scopes: ["source.coffee", "constant.language.boolean.true.coffee"]
     expect(tokens[2]).toEqual value: "if", scopes: ["source.coffee", "keyword.control.coffee"]
     expect(tokens[4]).toEqual value: "false", scopes: ["source.coffee", "constant.language.boolean.false.coffee"]
+
+  it "tokenizes destructuring assignments", ->
+    {tokens} = grammar.tokenizeLine("{something} = hi")
+    expect(tokens[0]).toEqual value: "{", scopes: ["source.coffee", "meta.variable.assignment.destructured.object.coffee", "punctuation.definition.destructuring.begin.bracket.curly.coffee"]
+    expect(tokens[1]).toEqual value: "something", scopes: ["source.coffee", "meta.variable.assignment.destructured.object.coffee", "variable.assignment.coffee", "variable.assignment.coffee"]
+    expect(tokens[2]).toEqual value: "}", scopes: ["source.coffee", "meta.variable.assignment.destructured.object.coffee", "punctuation.definition.destructuring.end.bracket.curly.coffee"]
+    expect(tokens[4]).toEqual value: "=", scopes: ["source.coffee", "meta.variable.assignment.destructured.object.coffee", "keyword.operator.coffee"]
+    expect(tokens[5]).toEqual value: " hi", scopes: ["source.coffee"]
+
+    {tokens} = grammar.tokenizeLine("{'} ='}") # Make sure this *isn't* tokenized as a destructuring assignment
+    expect(tokens[0]).not.toEqual value: "{", scopes: ["source.coffee", "meta.variable.assignment.destructured.object.coffee", "punctuation.definition.destructuring.begin.bracket.curly.coffee"]


### PR DESCRIPTION
Fixes #57

I also took the liberty of rescoping some things (for example, `{` is *clearly* not a `keyword.operator`).

This regex might be able to be cleaned up a bit more...I would do the following, but I'm not sure if everything that would match is valid:
```coffee
'begin': '(?<=\\s|^)({)(?=(.+?)}\\s+=)'
  'beginCaptures':
    '1':
      'name': 'punctuation.definition.destructuring.begin.bracket.curly.coffee'
    '2':
      'patterns': [
        {
          # move the patterns down below up here and get rid of those
        }
      ]
```
Some advice from someone who's more seasoned with Coffeescript would be nice.