### PR TITLE
Set tab length and force soft tabs

### DIFF
--- a/settings/language-coffee-script.cson
+++ b/settings/language-coffee-script.cson
@@ -1,6 +1,8 @@
 '.source.coffee, .source.litcoffee, .source.coffee.md':
   'editor':
     'commentStart': '# '
+    'softTabs': true
+    'tabLength': 2
 '.source.coffee':
   'editor':
     'autoIndentOnPaste': false


### PR DESCRIPTION
Coffeescript standard soft tab size is two spaces. It should be always used, even in CSON configs.