### PR TITLE
Add highlighting for Oniguruma regex comments

### DIFF
--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -44,6 +44,25 @@
       '0':
         'name': 'punctuation.definition.string.end.coffee'
     'name': 'string.quoted.heredoc.coffee'
+    'patterns': [
+      {
+        'begin': '\\(\\?#'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.comment.begin.coffee'
+        'end': '\\)|(?=\'\'\')'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.comment.end.coffee'
+        'name': 'comment.block.oniguruma.coffee'
+        'patterns': [
+          {
+            'match': '\\\\.'
+            'name': 'constant.character.escape.backslash.coffee'
+          }
+        ]
+      }
+    ]
   }
   {
     'begin': '"""'
@@ -59,6 +78,23 @@
       {
         'match': '\\\\.'
         'name': 'constant.character.escape.coffee'
+      }
+      {
+        'begin': '\\(\\?#'
+        'beginCaptures':
+          '0':
+            'name': 'punctuation.definition.comment.begin.coffee'
+        'end': '\\)|(?=""")'
+        'endCaptures':
+          '0':
+            'name': 'punctuation.definition.comment.end.coffee'
+        'name': 'comment.block.oniguruma.coffee'
+        'patterns': [
+          {
+            'match': '\\\\.'
+            'name': 'constant.character.escape.backslash.coffee'
+          }
+        ]
       }
       {
         'include': '#interpolated_coffee'
@@ -384,6 +420,23 @@
             'name': 'constant.character.escape.coffee'
           }
           {
+            'begin': '\\(\\?#'
+            'beginCaptures':
+              '0':
+                'name': 'punctuation.definition.comment.begin.coffee'
+            'end': '\\)|(?=")'
+            'endCaptures':
+              '0':
+                'name': 'punctuation.definition.comment.end.coffee'
+            'name': 'comment.block.oniguruma.coffee'
+            'patterns': [
+              {
+                'match': '\\\\.'
+                'name': 'constant.character.escape.backslash.coffee'
+              }
+            ]
+          }
+          {
             'include': '#interpolated_coffee'
           }
         ]
@@ -445,6 +498,23 @@
           {
             'match': '\\\\(x\\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)'
             'name': 'constant.character.escape.coffee'
+          }
+          {
+            'begin': '\\(\\?#'
+            'beginCaptures':
+              '0':
+                'name': 'punctuation.definition.comment.begin.coffee'
+            'end': '\\)|(?=\')'
+            'endCaptures':
+              '0':
+                'name': 'punctuation.definition.comment.end.coffee'
+            'name': 'comment.block.oniguruma.coffee'
+            'patterns': [
+              {
+                'match': '\\\\.'
+                'name': 'constant.character.escape.backslash.coffee'
+              }
+            ]
           }
         ]
       }

--- a/spec/coffee-script-spec.coffee
+++ b/spec/coffee-script-spec.coffee
@@ -303,3 +303,26 @@ describe "CoffeeScript grammar", ->
     expect(tokens[0]).toEqual value: "true", scopes: ["source.coffee", "constant.language.boolean.true.coffee"]
     expect(tokens[2]).toEqual value: "if", scopes: ["source.coffee", "keyword.control.coffee"]
     expect(tokens[4]).toEqual value: "false", scopes: ["source.coffee", "constant.language.boolean.false.coffee"]
+
+  it "tokenizes Oniguruma-regex comments in strings", ->
+    {tokens} = grammar.tokenizeLine('\"a (?# X Y\\\" Z \\\\\\\" 123) ABC\"')
+    expect(tokens[0]).toEqual  value: "\"",   scopes: ["source.coffee", "string.quoted.double.coffee", "punctuation.definition.string.begin.coffee"]
+    expect(tokens[1]).toEqual  value: "a ",   scopes: ["source.coffee", "string.quoted.double.coffee"]
+    expect(tokens[2]).toEqual  value: "(?#",  scopes: ["source.coffee", "string.quoted.double.coffee", "comment.block.oniguruma.coffee", "punctuation.definition.comment.begin.coffee"]
+    expect(tokens[3]).toEqual  value: " X Y", scopes: ["source.coffee", "string.quoted.double.coffee", "comment.block.oniguruma.coffee"]
+    expect(tokens[4]).toEqual  value: "\\\"", scopes: ["source.coffee", "string.quoted.double.coffee", "comment.block.oniguruma.coffee", "constant.character.escape.backslash.coffee"]
+    expect(tokens[5]).toEqual  value: " Z ",  scopes: ["source.coffee", "string.quoted.double.coffee", "comment.block.oniguruma.coffee"]
+    expect(tokens[6]).toEqual  value: "\\\\", scopes: ["source.coffee", "string.quoted.double.coffee", "comment.block.oniguruma.coffee", "constant.character.escape.backslash.coffee"]
+    expect(tokens[7]).toEqual  value: "\\\"", scopes: ["source.coffee", "string.quoted.double.coffee", "comment.block.oniguruma.coffee", "constant.character.escape.backslash.coffee"]
+    expect(tokens[8]).toEqual  value: " 123", scopes: ["source.coffee", "string.quoted.double.coffee", "comment.block.oniguruma.coffee"]
+    expect(tokens[9]).toEqual  value: ")",    scopes: ["source.coffee", "string.quoted.double.coffee", "comment.block.oniguruma.coffee", "punctuation.definition.comment.end.coffee"]
+    expect(tokens[10]).toEqual value: " ABC", scopes: ["source.coffee", "string.quoted.double.coffee"]
+    expect(tokens[11]).toEqual value: "\"",   scopes: ["source.coffee", "string.quoted.double.coffee", "punctuation.definition.string.end.coffee"]
+
+  it "does not ignore closing quote of unterminated Oniguruma comments", ->
+    {tokens} = grammar.tokenizeLine('\'a (?#\' z')
+    expect(tokens[0]).toEqual  value: "'",    scopes: ["source.coffee", "string.quoted.single.coffee", "punctuation.definition.string.begin.coffee"]
+    expect(tokens[1]).toEqual  value: "a ",   scopes: ["source.coffee", "string.quoted.single.coffee"]
+    expect(tokens[2]).toEqual  value: "(?#",  scopes: ["source.coffee", "string.quoted.single.coffee", "comment.block.oniguruma.coffee", "punctuation.definition.comment.begin.coffee"]
+    expect(tokens[3]).toEqual  value: "'",    scopes: ["source.coffee", "string.quoted.single.coffee", "punctuation.definition.string.end.coffee"]
+    expect(tokens[4]).toEqual  value: " z",   scopes: ["source.coffee"]


### PR DESCRIPTION
While writing a [monstrous centipede](https://github.com/Alhadis/language-apl/blob/e99d18934e479cb5d6f565833650459514c2474e/grammars/apl.cson#L321) of a regex for an Atom language grammar, I thought _"I can't possibly be the only dev wishing these annotations were highlighted..."_

Then through some combination of sleep-deprivation and too much (?:Coffee)?Script, I realised we could be looking at this...

<a href="https://cloud.githubusercontent.com/assets/2346707/14225599/552d4bc4-f914-11e5-8959-f1b35306fd30.png" target="_blank"><img width="500" src="https://cloud.githubusercontent.com/assets/2346707/14225599/552d4bc4-f914-11e5-8959-f1b35306fd30.png" alt="Figure 1" /></a>

The Oniguruma engine already supports [comment-groups](https://github.com/kkos/oniguruma/blob/master/doc/RE#L205), and it'd be ace to highlight them in quoted CoffeeScript strings.

I know plain `# Comment` lines are accepted in heredoc-strings (I don't know if that's a CoffeeScript feature, an Atom thing, or a First/TextMate thang). I tried adding highlighting for that too, but, uhm, quickly changed my mind:

<img width="260" alt="Figure 2" src="https://cloud.githubusercontent.com/assets/2346707/14225672/8ad02f10-f916-11e5-9bb6-6f9c5defff95.png">

Anyway, highlighting the Oniguruma comment-groups is probably more than enough.

I've added specs and terminator guards to ensure unclosed groups don't swallow the string's closing quote and miscolour the rest of the document... etc.