### PR TITLE
Prevent ".class" from triggering an auto-indent

### DIFF
--- a/settings/language-coffee-script.cson
+++ b/settings/language-coffee-script.cson
@@ -7,7 +7,7 @@
     'increaseIndentPattern': '(?x)
       ^\\s*
       (
-        .*\\bclass(\\s|$)
+        .*\\b(?<!\\.)class(\\s|$)
         | [a-zA-Z\\$_](\\w|\\$|:|\\.)*\\s*(?=\\:(\\s*\\(.*\\))?\\s*((=|-)>\\s*$))
         | [a-zA-Z\\$_](\\w|\\$|\\.)*\\s*(:|=)\\s*((if|while)(?!.*?then)|for|$)
         | \\b(if|else|unless|while|when)\\b(?!.*?then)|\\b(for|loop)\\b


### PR DESCRIPTION
I brewed a [small Chai plugin](https://github.com/DanBrooker/file-icons/blob/3109ce811728070e9d0077b4eb45936ef878df4a/lib/bin/run-tests#L13-L29) to check an HTML element's `classList` for one or more classes:

<img src="https://cloud.githubusercontent.com/assets/2346707/16708213/efb06a3a-462d-11e6-8d35-3d0756a37382.png" alt="Figure 1" width="472" />

To say it in spec-ese, `it "should not have done that", ->`.