### PR TITLE
Extend firstLineMatch support to include modelines

### DIFF
--- a/grammars/coffeescript (literate).cson
+++ b/grammars/coffeescript (literate).cson
@@ -6,6 +6,25 @@
 ]
 'name': 'CoffeeScript (Literate)'
 'scopeName': 'source.litcoffee'
+'firstLineMatch': '''(?x)
+  # Hashbang
+  ^\\#!.*(?:\\s|\\/)
+    coffee(?:\\s.+?)?\\s(?:-l|--literate)
+  (?:\\s|$)
+  |
+  # Modeline
+  (?i:
+    # Emacs
+    -\\*-(?:\\s*(?=[^:;\\s]+\\s*-\\*-)|(?:.*?[;\\s]|(?<=-\\*-))mode\\s*:\\s*)
+      litcoffee
+    (?=[\\s;]|(?<![-*])-\\*-).*?-\\*-
+    |
+    # Vim
+    (?:(?:\\s|^)vi(?:m[<=>]?\\d+|m)?|\\sex)(?=:(?=\\s*set?\\s[^\\n:]+:)|:(?!\\s*set?\\s))(?:(?:\\s|\\s*:\\s*)\\w*(?:\\s*=(?:[^\\n\\\\\\s]|\\\\.)*)?)*[\\s:](?:filetype|ft|syntax)\\s*=
+      litcoffee
+    (?=\\s|:|$)
+  )
+'''
 'patterns': [
   {
     'begin': '^(?=([ ]{4}|\\t)(?!$))'

--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -7,7 +7,25 @@
   'cson'
   '_coffee'
 ]
-'firstLineMatch': '^#!.*\\bcoffee'
+'firstLineMatch': '''(?x)
+  # Hashbang
+  ^\\#!.*(?:\\s|\\/)
+    coffee
+  (?:$|\\s)
+  |
+  # Modeline
+  (?i:
+    # Emacs
+    -\\*-(?:\\s*(?=[^:;\\s]+\\s*-\\*-)|(?:.*?[;\\s]|(?<=-\\*-))mode\\s*:\\s*)
+      coffee
+    (?=[\\s;]|(?<![-*])-\\*-).*?-\\*-
+    |
+    # Vim
+    (?:(?:\\s|^)vi(?:m[<=>]?\\d+|m)?|\\sex)(?=:(?=\\s*set?\\s[^\\n:]+:)|:(?!\\s*set?\\s))(?:(?:\\s|\\s*:\\s*)\\w*(?:\\s*=(?:[^\\n\\\\\\s]|\\\\.)*)?)*[\\s:](?:filetype|ft|syntax)\\s*=
+      coffee
+    (?=\\s|:|$)
+  )
+'''
 'patterns': [
   {
     'captures':

--- a/spec/coffee-script-literate-spec.coffee
+++ b/spec/coffee-script-literate-spec.coffee
@@ -20,3 +20,103 @@ describe "CoffeeScript (Literate) grammar", ->
           1 + 2
     '''
     expect(tokens[3][1]).toEqual value: "1", scopes: ["source.litcoffee", "markup.raw.block.markdown", "constant.numeric.coffee"]
+
+  describe "firstLineMatch", ->
+    it "recognises interpreter directives", ->
+      valid = """
+        #!/usr/local/bin/coffee --no-header --literate -w
+        #!/usr/local/bin/coffee -l
+        #!/usr/local/bin/env coffee --literate -w
+      """
+      for line in valid.split /\n/
+        expect(grammar.firstLineRegex.scanner.findNextMatchSync(line)).not.toBeNull()
+
+      invalid = """
+        #!/usr/local/bin/coffee --no-head -literate -w
+        #!/usr/local/bin/coffee --wl
+        #!/usr/local/bin/env coffee --illiterate -w=l
+      """
+      for line in invalid.split /\n/
+        expect(grammar.firstLineRegex.scanner.findNextMatchSync(line)).toBeNull()
+
+    it "recognises Emacs modelines", ->
+      valid = """
+        #-*- litcoffee -*-
+        #-*- mode: litcoffee -*-
+        /* -*-litcoffee-*- */
+        // -*- litcoffee -*-
+        /* -*- mode:LITCOFFEE -*- */
+        // -*- font:bar;mode:LitCoffee -*-
+        // -*- font:bar;mode:litcoffee;foo:bar; -*-
+        // -*-font:mode;mode:litcoffee-*-
+        // -*- foo:bar mode: litcoffee bar:baz -*-
+        " -*-foo:bar;mode:litcoffee;bar:foo-*- ";
+        " -*-font-mode:foo;mode:LITcofFEE;foo-bar:quux-*-"
+        "-*-font:x;foo:bar; mode : litCOFFEE; bar:foo;foooooo:baaaaar;fo:ba;-*-";
+        "-*- font:x;foo : bar ; mode : LiTcOFFEe ; bar : foo ; foooooo:baaaaar;fo:ba-*-";
+      """
+      for line in valid.split /\n/
+        expect(grammar.firstLineRegex.scanner.findNextMatchSync(line)).not.toBeNull()
+
+      invalid = """
+        /* --*litcoffee-*- */
+        /* -*-- litcoffee -*-
+        /* -*- -- litcoffee -*-
+        /* -*- LITCOFFEE -;- -*-
+        // -*- itsLitCoffeeFam -*-
+        // -*- litcoffee; -*-
+        // -*- litcoffee-stuff -*-
+        /* -*- model:litcoffee -*-
+        /* -*- indent-mode:litcoffee -*-
+        // -*- font:mode;litcoffee -*-
+        // -*- mode: -*- litcoffee
+        // -*- mode: burnt-because-litcoffee -*-
+        // -*-font:mode;mode:litcoffee--*-
+      """
+      for line in invalid.split /\n/
+        expect(grammar.firstLineRegex.scanner.findNextMatchSync(line)).toBeNull()
+
+    it "recognises Vim modelines", ->
+      valid = """
+        vim: se filetype=litcoffee:
+        # vim: se ft=litcoffee:
+        # vim: set ft=LITCOFFEE:
+        # vim: set filetype=litcoffee:
+        # vim: ft=LITCOFFEE
+        # vim: syntax=litcoffee
+        # vim: se syntax=litcoffee:
+        # ex: syntax=litcoffee
+        # vim:ft=LitCoffee
+        # vim600: ft=litcoffee
+        # vim>600: set ft=litcoffee:
+        # vi:noai:sw=3 ts=6 ft=litcoffee
+        # vi::::::::::noai:::::::::::: ft=litcoffee
+        # vim:ts=4:sts=4:sw=4:noexpandtab:ft=LITCOFFEE
+        # vi:: noai : : : : sw   =3 ts   =6 ft  =litCoffee
+        # vim: ts=4: pi sts=4: ft=litcoffee: noexpandtab: sw=4:
+        # vim: ts=4 sts=4: ft=litcoffee noexpandtab:
+        # vim:noexpandtab sts=4 ft=LitCOffEE ts=4
+        # vim:noexpandtab:ft=litcoffee
+        # vim:ts=4:sts=4 ft=litcoffee:noexpandtab:\x20
+        # vim:noexpandtab titlestring=hi\|there\\\\ ft=litcoffee ts=4
+      """
+      for line in valid.split /\n/
+        expect(grammar.firstLineRegex.scanner.findNextMatchSync(line)).not.toBeNull()
+
+      invalid = """
+        ex: se filetype=litcoffee:
+        _vi: se filetype=litcoffee:
+         vi: se filetype=litcoffee
+        # vim set ft=illitcoffee
+        # vim: soft=litcoffee
+        # vim: clean-syntax=litcoffee:
+        # vim set ft=litcoffee:
+        # vim: setft=litcoffee:
+        # vim: se ft=litcoffee backupdir=tmp
+        # vim: set ft=LITCOFFEE set cmdheight=1
+        # vim:noexpandtab sts:4 ft:litcoffee ts:4
+        # vim:noexpandtab titlestring=hi\\|there\\ ft=litcoffee ts=4
+        # vim:noexpandtab titlestring=hi\\|there\\\\\\ ft=litcoffee ts=4
+      """
+      for line in invalid.split /\n/
+        expect(grammar.firstLineRegex.scanner.findNextMatchSync(line)).toBeNull()


### PR DESCRIPTION
## Chapter 10 of <i>"The Neverending Story of Alhadis's modeline-related pull requests"</i>

Copy+pasta from 5846f59:
* **Added:** Hashbang recognition for Literate CoffeeScript

* **Fixed:** Incorrect boundary matching of existing hashbang; previously, a line like `#!/projects/coffeelabs/run` would've triggered the grammar.

* **Added:** Modeline support for Emacs and Vim. Neither editor supports the language out-of-the-box, but community-authored modes exist, both with the typical mode-name choices of `coffee` and `litcoffee`.

**See:**
- https://github.com/kchmck/vim-coffee-script
- https://github.com/defunkt/coffee-mode
- https://github.com/jashkenas/coffeescript/wiki/Text-editor-plugins