### PR TITLE
Auto-indent colons

### DIFF
--- a/settings/language-coffee-script.cson
+++ b/settings/language-coffee-script.cson
@@ -14,5 +14,6 @@
         | \\b(try|finally|catch|((catch|switch)\\s+\\S.*))\\b\\s*$
         | .*[-=]>\\s*$
         | .*[\\{\\[]\\s*$
+        | .*:\\s*$
       )'
     'decreaseIndentPattern': '^\\s*(\\}|\\]|\\b(else|catch|finally)\\b)$'


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Simple change: if the last character on a line is a colon, increase the next line's indentation level.

### Alternate Designs

None.

### Benefits

Much less tabbing when writing CSON.  Now only shift-tabbing!... :(

### Possible Drawbacks

I went through a quick mental checklist and couldn't think of any scenario where you wouldn't want the next line to be indented, but I could be wrong.

### Applicable Issues

None.