### PR TITLE
Provide more accurate regex detection

### DIFF
--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -137,7 +137,7 @@
     ]
   }
   {
-    'match': '(/)(?![/*+?])(.+)(/)[gimuy]*(?!\\s*[\\w$])'
+    'match': '(?<![\\w$])(/)(?![/*+?])(.+)(/)[gimuy]*(?!\\s*[\\w$/(])'
     'captures':
       '1':
         'name': 'punctuation.definition.string.begin.coffee'

--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -135,23 +135,21 @@
         'include': '#heregexp'
       }
     ]
-
   }
   {
-    'begin': '/(?![/*+?])(?=([^\\\\]|\\\\.)*?/[gimuy]*)'
-    'beginCaptures':
-      '0':
-        'name': 'punctuation.definition.string.begin.coffee'
-    'end': '(/)[gimuy]*'
-    'endCaptures':
+    'match': '(/)(?![/*+?])(.+)(/)[gimuy]*(?!\\s*[\\w$])'
+    'captures':
       '1':
+        'name': 'punctuation.definition.string.begin.coffee'
+      '2':
+        'patterns': [
+          {
+            'include': 'source.js.regexp'
+          }
+        ]
+      '3':
         'name': 'punctuation.definition.string.end.coffee'
     'name': 'string.regexp.coffee'
-    'patterns': [
-      {
-        'include': 'source.js.regexp'
-      }
-    ]
   }
   {
     'match': '\\b(?<![\\.\\$])(break|by|catch|continue|else|finally|for|in|of|if|return|switch|then|throw|try|unless|when|while|until|loop|do|(?<=for)\\s+own)(?!\\s*:)\\b'

--- a/spec/coffee-script-spec.coffee
+++ b/spec/coffee-script-spec.coffee
@@ -433,6 +433,19 @@ describe "CoffeeScript grammar", ->
       {tokens} = grammar.tokenizeLine("a / b + c / d")
       expect(tokens[1]).toEqual value: "/", scopes: ["source.coffee", "keyword.operator.coffee"]
       expect(tokens[2]).toEqual value: " b ", scopes: ["source.coffee"]
+      expect(tokens[5]).toEqual value: "/", scopes: ["source.coffee", "keyword.operator.coffee"]
+
+      {tokens} = grammar.tokenizeLine("a / 2 / (3)")
+      expect(tokens[1]).toEqual value: "/", scopes: ["source.coffee", "keyword.operator.coffee"]
+      expect(tokens[3]).toEqual value: "2", scopes: ["source.coffee", "constant.numeric.coffee"]
+      expect(tokens[5]).toEqual value: "/", scopes: ["source.coffee", "keyword.operator.coffee"]
+
+    it "does not tokenize comments with URLs in them as regex", ->
+      # Disclaimer: This does not fix when comments contain only slashes, such as `a / something # comment /`
+      {tokens} = grammar.tokenizeLine("canvas.width/2 # https://github.com/atom/language-coffee-script/issues/112")
+      expect(tokens[3]).toEqual value: "/", scopes: ["source.coffee", "keyword.operator.coffee"]
+      expect(tokens[6]).toEqual value: "#", scopes: ["source.coffee", "comment.line.number-sign.coffee", "punctuation.definition.comment.coffee"]
+      expect(tokens[7]).toEqual value: " https://github.com/atom/language-coffee-script/issues/112", scopes: ["source.coffee", "comment.line.number-sign.coffee"]
 
   describe "firstLineMatch", ->
     it "recognises interpreter directives", ->


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

We now use a `match` instead of a begin/end because regexes can only be on a single line.  In addition, we now check to make sure that there is no word following the end of a potential regex expression, as that would be invalid.

### Alternate Designs

None.

### Benefits

Potentially more accurate regex detection and differentiation between division.

### Possible Drawbacks

Regex detection is ripe for regressions, as can be seen by #112.  Combined with the lack of specs...

### Applicable Issues

Fixes #112

@GarmOfGnipahellir, @julians, @ezekg, @1j01 if one of you could please test this out and let me know the results, that would be appreciated.  I can provide steps if necessary.