### PR TITLE
Tokenise backslash in escape sequences

### DIFF
--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -60,6 +60,15 @@
       '0':
         'name': 'punctuation.definition.string.end.coffee'
     'name': 'string.quoted.heredoc.coffee'
+    'patterns': [
+      {
+        'captures':
+          '1':
+            'name': 'punctuation.definition.escape.backslash.coffee'
+        'match': '(\\\\).'
+        'name': 'constant.character.escape.backslash.coffee'
+      }
+    ]
   }
   {
     'begin': '"""'
@@ -73,8 +82,11 @@
     'name': 'string.quoted.double.heredoc.coffee'
     'patterns': [
       {
-        'match': '\\\\.'
-        'name': 'constant.character.escape.coffee'
+        'captures':
+          '1':
+            'name': 'punctuation.definition.escape.backslash.coffee'
+        'match': '(\\\\).'
+        'name': 'constant.character.escape.backslash.coffee'
       }
       {
         'include': '#interpolated_coffee'
@@ -381,7 +393,10 @@
         'name': 'string.quoted.double.coffee'
         'patterns': [
           {
-            'match': '\\\\(x\\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]|37[0-7]?|[4-7][0-7]?|.)'
+            'captures':
+              '1':
+                'name': 'punctuation.definition.escape.backslash.coffee'
+            'match': '(\\\\)(x\\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]|37[0-7]?|[4-7][0-7]?|.)'
             'name': 'constant.character.escape.coffee'
           }
           {
@@ -444,8 +459,11 @@
         'name': 'string.quoted.single.coffee'
         'patterns': [
           {
-            'match': '\\\\(x\\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)'
-            'name': 'constant.character.escape.coffee'
+            'captures':
+              '1':
+                'name': 'punctuation.definition.escape.backslash.coffee'
+            'match': '(\\\\)(x\\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)'
+            'name': 'constant.character.escape.backslash.coffee'
           }
         ]
       }

--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -397,7 +397,7 @@
               '1':
                 'name': 'punctuation.definition.escape.backslash.coffee'
             'match': '(\\\\)(x\\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]|37[0-7]?|[4-7][0-7]?|.)'
-            'name': 'constant.character.escape.coffee'
+            'name': 'constant.character.escape.backslash.coffee'
           }
           {
             'include': '#interpolated_coffee'

--- a/spec/coffee-script-spec.coffee
+++ b/spec/coffee-script-spec.coffee
@@ -462,6 +462,18 @@ describe "CoffeeScript grammar", ->
       expect(tokens[9]).toEqual value: 'c', scopes: ['source.coffee', 'string.quoted.double.coffee']
       expect(tokens[10]).toEqual value: '"', scopes: ['source.coffee', 'string.quoted.double.coffee', 'punctuation.definition.string.end.coffee']
 
+      {tokens} = grammar.tokenizeLine('"\\a\\t\\a\\b"')
+      expect(tokens[0]).toEqual value: '"', scopes: ['source.coffee', 'string.quoted.double.coffee', 'punctuation.definition.string.begin.coffee']
+      expect(tokens[1]).toEqual value: '\\', scopes: ['source.coffee', 'string.quoted.double.coffee', 'constant.character.escape.backslash.coffee', 'punctuation.definition.escape.backslash.coffee']
+      expect(tokens[2]).toEqual value: 'a', scopes: ['source.coffee', 'string.quoted.double.coffee', 'constant.character.escape.backslash.coffee']
+      expect(tokens[3]).toEqual value: '\\', scopes: ['source.coffee', 'string.quoted.double.coffee', 'constant.character.escape.backslash.coffee', 'punctuation.definition.escape.backslash.coffee']
+      expect(tokens[4]).toEqual value: 't', scopes: ['source.coffee', 'string.quoted.double.coffee', 'constant.character.escape.backslash.coffee']
+      expect(tokens[5]).toEqual value: '\\', scopes: ['source.coffee', 'string.quoted.double.coffee', 'constant.character.escape.backslash.coffee', 'punctuation.definition.escape.backslash.coffee']
+      expect(tokens[6]).toEqual value: 'a', scopes: ['source.coffee', 'string.quoted.double.coffee', 'constant.character.escape.backslash.coffee']
+      expect(tokens[7]).toEqual value: '\\', scopes: ['source.coffee', 'string.quoted.double.coffee', 'constant.character.escape.backslash.coffee', 'punctuation.definition.escape.backslash.coffee']
+      expect(tokens[8]).toEqual value: 'b', scopes: ['source.coffee', 'string.quoted.double.coffee', 'constant.character.escape.backslash.coffee']
+      expect(tokens[9]).toEqual value: '"', scopes: ['source.coffee', 'string.quoted.double.coffee', 'punctuation.definition.string.end.coffee']
+
     it "tokenises leading backslashes in single-quoted strings", ->
       {tokens} = grammar.tokenizeLine("'a\\\\b\\\\\\\\c'")
       expect(tokens[0]).toEqual value: "'", scopes: ['source.coffee', 'string.quoted.single.coffee', 'punctuation.definition.string.begin.coffee']
@@ -475,6 +487,18 @@ describe "CoffeeScript grammar", ->
       expect(tokens[8]).toEqual value: '\\', scopes: ['source.coffee', 'string.quoted.single.coffee', 'constant.character.escape.backslash.coffee']
       expect(tokens[9]).toEqual value: 'c', scopes: ['source.coffee', 'string.quoted.single.coffee']
       expect(tokens[10]).toEqual value: "'", scopes: ['source.coffee', 'string.quoted.single.coffee', 'punctuation.definition.string.end.coffee']
+
+      {tokens} = grammar.tokenizeLine("'\\a\\t\\a\\b'")
+      expect(tokens[0]).toEqual value: "'", scopes: ['source.coffee', 'string.quoted.single.coffee', 'punctuation.definition.string.begin.coffee']
+      expect(tokens[1]).toEqual value: '\\', scopes: ['source.coffee', 'string.quoted.single.coffee', 'constant.character.escape.backslash.coffee', 'punctuation.definition.escape.backslash.coffee']
+      expect(tokens[2]).toEqual value: 'a', scopes: ['source.coffee', 'string.quoted.single.coffee', 'constant.character.escape.backslash.coffee']
+      expect(tokens[3]).toEqual value: '\\', scopes: ['source.coffee', 'string.quoted.single.coffee', 'constant.character.escape.backslash.coffee', 'punctuation.definition.escape.backslash.coffee']
+      expect(tokens[4]).toEqual value: 't', scopes: ['source.coffee', 'string.quoted.single.coffee', 'constant.character.escape.backslash.coffee']
+      expect(tokens[5]).toEqual value: '\\', scopes: ['source.coffee', 'string.quoted.single.coffee', 'constant.character.escape.backslash.coffee', 'punctuation.definition.escape.backslash.coffee']
+      expect(tokens[6]).toEqual value: 'a', scopes: ['source.coffee', 'string.quoted.single.coffee', 'constant.character.escape.backslash.coffee']
+      expect(tokens[7]).toEqual value: '\\', scopes: ['source.coffee', 'string.quoted.single.coffee', 'constant.character.escape.backslash.coffee', 'punctuation.definition.escape.backslash.coffee']
+      expect(tokens[8]).toEqual value: 'b', scopes: ['source.coffee', 'string.quoted.single.coffee', 'constant.character.escape.backslash.coffee']
+      expect(tokens[9]).toEqual value: "'", scopes: ['source.coffee', 'string.quoted.single.coffee', 'punctuation.definition.string.end.coffee']
 
   describe "firstLineMatch", ->
     it "recognises interpreter directives", ->

--- a/spec/coffee-script-spec.coffee
+++ b/spec/coffee-script-spec.coffee
@@ -447,6 +447,35 @@ describe "CoffeeScript grammar", ->
       expect(tokens[6]).toEqual value: "#", scopes: ["source.coffee", "comment.line.number-sign.coffee", "punctuation.definition.comment.coffee"]
       expect(tokens[7]).toEqual value: " https://github.com/atom/language-coffee-script/issues/112", scopes: ["source.coffee", "comment.line.number-sign.coffee"]
 
+  describe "escape sequences in strings", ->
+    it "tokenises leading backslashes in double-quoted strings", ->
+      {tokens} = grammar.tokenizeLine('"a\\\\b\\\\\\\\c"')
+      expect(tokens[0]).toEqual value: '"', scopes: ['source.coffee', 'string.quoted.double.coffee', 'punctuation.definition.string.begin.coffee']
+      expect(tokens[1]).toEqual value: 'a', scopes: ['source.coffee', 'string.quoted.double.coffee']
+      expect(tokens[2]).toEqual value: '\\', scopes: ['source.coffee', 'string.quoted.double.coffee', 'constant.character.escape.backslash.coffee', 'punctuation.definition.escape.backslash.coffee']
+      expect(tokens[3]).toEqual value: '\\', scopes: ['source.coffee', 'string.quoted.double.coffee', 'constant.character.escape.backslash.coffee']
+      expect(tokens[4]).toEqual value: 'b', scopes: ['source.coffee', 'string.quoted.double.coffee']
+      expect(tokens[5]).toEqual value: '\\', scopes: ['source.coffee', 'string.quoted.double.coffee', 'constant.character.escape.backslash.coffee', 'punctuation.definition.escape.backslash.coffee']
+      expect(tokens[6]).toEqual value: '\\', scopes: ['source.coffee', 'string.quoted.double.coffee', 'constant.character.escape.backslash.coffee']
+      expect(tokens[7]).toEqual value: '\\', scopes: ['source.coffee', 'string.quoted.double.coffee', 'constant.character.escape.backslash.coffee', 'punctuation.definition.escape.backslash.coffee']
+      expect(tokens[8]).toEqual value: '\\', scopes: ['source.coffee', 'string.quoted.double.coffee', 'constant.character.escape.backslash.coffee']
+      expect(tokens[9]).toEqual value: 'c', scopes: ['source.coffee', 'string.quoted.double.coffee']
+      expect(tokens[10]).toEqual value: '"', scopes: ['source.coffee', 'string.quoted.double.coffee', 'punctuation.definition.string.end.coffee']
+
+    it "tokenises leading backslashes in single-quoted strings", ->
+      {tokens} = grammar.tokenizeLine("'a\\\\b\\\\\\\\c'")
+      expect(tokens[0]).toEqual value: "'", scopes: ['source.coffee', 'string.quoted.single.coffee', 'punctuation.definition.string.begin.coffee']
+      expect(tokens[1]).toEqual value: 'a', scopes: ['source.coffee', 'string.quoted.single.coffee']
+      expect(tokens[2]).toEqual value: '\\', scopes: ['source.coffee', 'string.quoted.single.coffee', 'constant.character.escape.backslash.coffee', 'punctuation.definition.escape.backslash.coffee']
+      expect(tokens[3]).toEqual value: '\\', scopes: ['source.coffee', 'string.quoted.single.coffee', 'constant.character.escape.backslash.coffee']
+      expect(tokens[4]).toEqual value: 'b', scopes: ['source.coffee', 'string.quoted.single.coffee']
+      expect(tokens[5]).toEqual value: '\\', scopes: ['source.coffee', 'string.quoted.single.coffee', 'constant.character.escape.backslash.coffee', 'punctuation.definition.escape.backslash.coffee']
+      expect(tokens[6]).toEqual value: '\\', scopes: ['source.coffee', 'string.quoted.single.coffee', 'constant.character.escape.backslash.coffee']
+      expect(tokens[7]).toEqual value: '\\', scopes: ['source.coffee', 'string.quoted.single.coffee', 'constant.character.escape.backslash.coffee', 'punctuation.definition.escape.backslash.coffee']
+      expect(tokens[8]).toEqual value: '\\', scopes: ['source.coffee', 'string.quoted.single.coffee', 'constant.character.escape.backslash.coffee']
+      expect(tokens[9]).toEqual value: 'c', scopes: ['source.coffee', 'string.quoted.single.coffee']
+      expect(tokens[10]).toEqual value: "'", scopes: ['source.coffee', 'string.quoted.single.coffee', 'punctuation.definition.string.end.coffee']
+
   describe "firstLineMatch", ->
     it "recognises interpreter directives", ->
       valid = """


### PR DESCRIPTION
Decided to do this before the JSDoc grammar starts getting hairy. It enables a user to style the first backslash of a double-escape with their stylesheet:

~~~less
.@{_}coffee{
	&.@{_}string{
		.@{_}punctuation.@{_}definition.@{_}escape.@{_}backslash{
			opacity: .2;
		}
	}
}
~~~

Which yields noticeable improvement to readability when you're working with CSON grammars:

<img src="https://cloud.githubusercontent.com/assets/2346707/23414535/653b2eba-fe30-11e6-8af3-8907475762c6.gif" width="271" alt="Figure 1" />

### ~~Caveats~~

~~I haven't added specs because I want to focus on atom/language-javascript#495. I figured if I was going through the trouble of forking and dev-linking another package to make another job easier, I may as well share it.~~

~~Let me know if you still want me to add specs; but I won't get to it instantly.~~

**EDIT:** Belay that, specs added.

### Addendum

FTR, it actually *is* possible to target the first character using the `::first-letter` pseudo-element, but it's very limited in what properties can be applied: and that excludes `opacity`. Alternative would've been to squabble with text-colour, and... yeah, nah thanks.