### PR TITLE
Stop regex at the first non-escaped forwards slash

### DIFF
--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -149,7 +149,7 @@
     ]
   }
   {
-    'match': '(?<![\\w$])(/)(?![/*+?])(.+)(/)[gimuy]*(?!\\s*[\\w$/(])'
+    'match': '(?<![\\w$])(/)(?![/*+?])(.+?)(/)[gimuy]*(?!\\s*[\\w$/(])'
     'captures':
       '1':
         'name': 'punctuation.definition.string.begin.coffee'

--- a/spec/coffee-script-spec.coffee
+++ b/spec/coffee-script-spec.coffee
@@ -447,6 +447,18 @@ describe "CoffeeScript grammar", ->
       expect(tokens[6]).toEqual value: "#", scopes: ["source.coffee", "comment.line.number-sign.coffee", "punctuation.definition.comment.coffee"]
       expect(tokens[7]).toEqual value: " https://github.com/atom/language-coffee-script/issues/112", scopes: ["source.coffee", "comment.line.number-sign.coffee"]
 
+    it "stops tokenizing regex at the first non-escaped forwards slash", ->
+      {tokens} = grammar.tokenizeLine("path.replace(/\\\\/g, '/')")
+      expect(tokens[4]).toEqual value: "/", scopes: ["source.coffee", "string.regexp.coffee", "punctuation.definition.string.begin.coffee"]
+      expect(tokens[6]).toEqual value: "/", scopes: ["source.coffee", "string.regexp.coffee", "punctuation.definition.string.end.coffee"]
+      expect(tokens[11]).toEqual value: "/", scopes: ["source.coffee", "string.quoted.single.coffee"]
+
+      {tokens} = grammar.tokenizeLine("path.replace(/\\\\\\//g, '/')")
+      expect(tokens[4]).toEqual value: "/", scopes: ["source.coffee", "string.regexp.coffee", "punctuation.definition.string.begin.coffee"]
+      expect(tokens[6]).toEqual value: "\\/", scopes: ["source.coffee", "string.regexp.coffee", "constant.character.escape.backslash.regexp"]
+      expect(tokens[7]).toEqual value: "/", scopes: ["source.coffee", "string.regexp.coffee", "punctuation.definition.string.end.coffee"]
+      expect(tokens[12]).toEqual value: "/", scopes: ["source.coffee", "string.quoted.single.coffee"]
+
   describe "escape sequences in strings", ->
     it "tokenises leading backslashes in double-quoted strings", ->
       {tokens} = grammar.tokenizeLine('"a\\\\b\\\\\\\\c"')


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Stop matching regex at the first non-escaped forwards slash.

### Alternate Designs

None.

### Benefits

Prevents highlighting errors when other forward slashes are further down the line

### Possible Drawbacks

None.

### Applicable Issues

Fixes #118

/cc @as-cii