### PR TITLE
Added new keywords to bring package up to date with CoffeeScript 1.12 and 2.0

### DIFF
--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -164,7 +164,7 @@
     'name': 'string.regexp.coffee'
   }
   {
-    'match': '\\b(?<![\\.\\$])(break|by|catch|continue|else|finally|for|in|of|if|return|switch|then|throw|try|unless|when|while|until|loop|do|(?<=for)\\s+own)(?!\\s*:)\\b'
+    'match': '\\b(?<![\\.\\$])(break|by|catch|continue|else|finally|for|in|of|if|return|switch|then|throw|try|unless|when|while|until|loop|do|export|import|default|from|as|yield|async|await|(?<=for)\\s+own)(?!\\s*:)\\b'
     'name': 'keyword.control.coffee'
   }
   {
@@ -172,7 +172,7 @@
     'name': 'keyword.operator.coffee'
   }
   {
-    'match': '\\b(?<![\\.\\$])(case|default|function|var|void|with|const|let|enum|export|import|native|__hasProp|__extends|__slice|__bind|__indexOf|implements|interface|package|private|protected|public|static|yield)(?!\\s*:)\\b'
+    'match': '\\b(?<![\\.\\$])(case|function|var|void|with|const|let|enum|native|__hasProp|__extends|__slice|__bind|__indexOf|implements|interface|package|private|protected|public|static)(?!\\s*:)\\b'
     'name': 'keyword.reserved.coffee'
   }
   {


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Added the following keywords for [es2015 module syntax support](http://coffeescript.org/#modules):
- import
- export
- default
- as
- from

For [async/await and generators](http://coffeescript.org/v2/#fat-arrow):
- async
- await
- yield

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

None.

### Benefits

<!-- What benefits will be realized by the code change? -->

Code using the new features will be more readable.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Functions with the same name as the new keywords _might_ look a little awkward.

### Applicable Issues

<!-- Enter any applicable Issues here -->

None.