### PR TITLE
Avoid using the ambiguous \h shorthand character

### DIFF
--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -462,7 +462,7 @@
             'captures':
               '1':
                 'name': 'punctuation.definition.escape.backslash.coffee'
-            'match': '(\\\\)(x\\h{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)'
+            'match': '(\\\\)(x[0-9A-Fa-f]{2}|[0-2][0-7]{0,2}|3[0-6][0-7]?|37[0-7]?|[4-7][0-7]?|.)'
             'name': 'constant.character.escape.backslash.coffee'
           }
         ]
@@ -485,7 +485,7 @@
         'name': 'constant.character.character-class.regexp'
       }
       {
-        'match': '\\\\([0-7]{3}|x\\h\\h|u\\h\\h\\h\\h)'
+        'match': '\\\\([0-7]{3}|x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4})'
         'name': 'constant.character.numeric.regexp'
       }
       {
@@ -578,7 +578,7 @@
                 'name': 'constant.character.control.regexp'
               '6':
                 'name': 'constant.character.escape.backslash.regexp'
-            'match': '(?:.|(\\\\(?:[0-7]{3}|x\\h\\h|u\\h\\h\\h\\h))|(\\\\c[A-Z])|(\\\\.))\\-(?:[^\\]\\\\]|(\\\\(?:[0-7]{3}|x\\h\\h|u\\h\\h\\h\\h))|(\\\\c[A-Z])|(\\\\.))'
+            'match': '(?:.|(\\\\(?:[0-7]{3}|x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}))|(\\\\c[A-Z])|(\\\\.))\\-(?:[^\\]\\\\]|(\\\\(?:[0-7]{3}|x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}))|(\\\\c[A-Z])|(\\\\.))'
             'name': 'constant.other.character-class.range.regexp'
           }
           {


### PR DESCRIPTION
### Description of the Change

Depending on the regular expression engine used, \h does not always
mean the same. With a PCRE engine, it matches white spaces, whereas,
with a Oniguruma engine, it matches hexademical digit characters.
Atom uses an Oniguruma engine, but github.com relies on a PCRE
engine.

### Alternate Designs

None were considered.

### Benefits

Makes the grammar PCRE-compatible, so that it can be used on github.com.

### Possible Drawbacks

I don't have any way to check these PCRE vs. Oniguruma discrepancies at the moment. I'm working on a new test at the Linguist-level to check for all known discrepancies.