### PR TITLE
Match regexes containing multiple escaped forward slashes

### DIFF
--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -149,19 +149,20 @@
     ]
   }
   {
-    'match': '(?<![\\w$])(/)(?![/*+?])(.+?)(/)[gimuy]*(?!\\s*[\\w$/(])'
-    'captures':
+    'begin': '(?<![\\w$])(/)(?=(?![/*+?])(.+)(/)[gimuy]*(?!\\s*[\\w$/(]))'
+    'beginCaptures':
       '1':
         'name': 'punctuation.definition.string.begin.coffee'
-      '2':
-        'patterns': [
-          {
-            'include': 'source.js.regexp'
-          }
-        ]
-      '3':
+    'end': '(/)[gimuy]*(?!\\s*[\\w$/(])'
+    'endCaptures':
+      '1':
         'name': 'punctuation.definition.string.end.coffee'
     'name': 'string.regexp.coffee'
+    'patterns': [
+      {
+        'include': 'source.js.regexp'
+      }
+    ]
   }
   {
     'match': '\\b(?<![\\.\\$])(break|by|catch|continue|else|finally|for|in|of|if|return|switch|then|throw|try|unless|when|while|until|loop|do|export|import|default|from|as|yield|async|await|(?<=for)\\s+own)(?!\\s*:)\\b'

--- a/spec/coffee-script-spec.coffee
+++ b/spec/coffee-script-spec.coffee
@@ -416,6 +416,15 @@ describe "CoffeeScript grammar", ->
       expect(tokens[2]).toEqual value: "\\/", scopes: ["source.coffee", "string.regexp.coffee", "constant.character.escape.backslash.regexp"]
       expect(tokens[3]).toEqual value: "/", scopes: ["source.coffee", "string.regexp.coffee", "punctuation.definition.string.end.coffee"]
 
+      {tokens} = grammar.tokenizeLine("/one\\/two!\\/three/")
+      expect(tokens[0]).toEqual value: "/", scopes: ["source.coffee", "string.regexp.coffee", "punctuation.definition.string.begin.coffee"]
+      expect(tokens[1]).toEqual value: "one", scopes: ["source.coffee", "string.regexp.coffee"]
+      expect(tokens[2]).toEqual value: "\\/", scopes: ["source.coffee", "string.regexp.coffee", "constant.character.escape.backslash.regexp"]
+      expect(tokens[3]).toEqual value: "two!", scopes: ["source.coffee", "string.regexp.coffee"]
+      expect(tokens[4]).toEqual value: "\\/", scopes: ["source.coffee", "string.regexp.coffee", "constant.character.escape.backslash.regexp"]
+      expect(tokens[5]).toEqual value: "three", scopes: ["source.coffee", "string.regexp.coffee"]
+      expect(tokens[6]).toEqual value: "/", scopes: ["source.coffee", "string.regexp.coffee", "punctuation.definition.string.end.coffee"]
+
     it "tokenizes regular expressions inside arrays", ->
       {tokens} = grammar.tokenizeLine("[/test/]")
       expect(tokens[0]).toEqual value: "[", scopes: ["source.coffee", "meta.brace.square.coffee"]


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

The regex regex just keeps getting regexier.  Who doesn't like a negative lookahead in a lookahead? 
 Now a begin/end match in an attempt to avoid some _very ugly_ lookbehinds that may not even be possible.

### Alternate Designs

Attempt to use lookbehinds.

### Benefits

Maybe this will be the last regex fix.

### Possible Drawbacks

Maybe this won't be the last regex fix.

### Applicable Issues

Fixes #127

/cc @Alhadis