### PR TITLE
Tokenize slices

### DIFF
--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -423,6 +423,29 @@
     ]
   }
   {
+    'begin': '\\['
+    'beginCaptures':
+      '0':
+        'name': 'punctuation.definition.array.begin.bracket.square.coffee'
+    'end': '\\]'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.array.end.bracket.square.coffee'
+    'patterns': [
+      {
+        'match': '(?<!\\.)\\.{3}' # ...
+        'name': 'keyword.operator.slice.exclusive.coffee'
+      }
+      {
+        'match': '(?<!\\.)\\.{2}' # ..
+        'name': 'keyword.operator.slice.inclusive.coffee'
+      }
+      {
+        'include': '$self'
+      }
+    ]
+  }
+  {
     'begin': '\\('
     'beginCaptures':
       '0':
@@ -436,10 +459,6 @@
         'include': '$self'
       }
     ]
-  }
-  {
-    'match': '\\[|\\]'
-    'name': 'meta.brace.square.coffee'
   }
   {
     'include': '#instance_variable'
@@ -741,6 +760,7 @@
             (?:\\B(\\.)[0-9]+[eE][+-]?[0-9]+\\b)|       # .1E+3
             (?:\\b[0-9]+[eE][+-]?[0-9]+\\b)|            # 1E+3
             (?:\\b[0-9]+(\\.)[0-9]+\\b)|                # 1.1
+            (?:\\b[0-9]+(?=\\.{2,3}))|                  # 1 followed by a slice
             (?:\\b[0-9]+(\\.)\\B)|                      # 1.
             (?:\\B(\\.)[0-9]+\\b)|                      # .1
             (?:\\b[0-9]+\\b(?!\\.))                     # 1

--- a/spec/coffee-script-spec.coffee
+++ b/spec/coffee-script-spec.coffee
@@ -29,11 +29,11 @@ describe "CoffeeScript grammar", ->
     expect(tokens[0]).toEqual value: "_class", scopes: ["source.coffee", "meta.function-call.coffee", "entity.name.function.coffee"]
 
     {tokens} = grammar.tokenizeLine("[class Foo]")
-    expect(tokens[0]).toEqual value: "[", scopes: ["source.coffee", "meta.brace.square.coffee"]
+    expect(tokens[0]).toEqual value: "[", scopes: ["source.coffee", "punctuation.definition.array.begin.bracket.square.coffee"]
     expect(tokens[1]).toEqual value: "class", scopes: ["source.coffee", "meta.class.coffee", "storage.type.class.coffee"]
     expect(tokens[2]).toEqual value: " ", scopes: ["source.coffee", "meta.class.coffee"]
     expect(tokens[3]).toEqual value: "Foo", scopes: ["source.coffee", "meta.class.coffee", "entity.name.type.class.coffee"]
-    expect(tokens[4]).toEqual value: "]", scopes: ["source.coffee", "meta.brace.square.coffee"]
+    expect(tokens[4]).toEqual value: "]", scopes: ["source.coffee", "punctuation.definition.array.end.bracket.square.coffee"]
 
     {tokens} = grammar.tokenizeLine("bar(class Foo)")
     expect(tokens[0]).toEqual value: "bar", scopes: ["source.coffee", "meta.function-call.coffee", "entity.name.function.coffee"]
@@ -489,30 +489,55 @@ describe "CoffeeScript grammar", ->
       {tokens} = grammar.tokenizeLine('123$illegal')
       expect(tokens[0]).toEqual value: '123$illegal', scopes: ['source.coffee', 'invalid.illegal.identifier.coffee']
 
-    describe "objects", ->
-      it "tokenizes them", ->
-        {tokens} = grammar.tokenizeLine('obj.prop')
-        expect(tokens[0]).toEqual value: 'obj', scopes: ['source.coffee', 'variable.other.object.coffee']
+  describe "objects", ->
+    it "tokenizes them", ->
+      {tokens} = grammar.tokenizeLine('obj.prop')
+      expect(tokens[0]).toEqual value: 'obj', scopes: ['source.coffee', 'variable.other.object.coffee']
 
-        {tokens} = grammar.tokenizeLine('$abc$.prop')
-        expect(tokens[0]).toEqual value: '$abc$', scopes: ['source.coffee', 'variable.other.object.coffee']
+      {tokens} = grammar.tokenizeLine('$abc$.prop')
+      expect(tokens[0]).toEqual value: '$abc$', scopes: ['source.coffee', 'variable.other.object.coffee']
 
-        {tokens} = grammar.tokenizeLine('$$.prop')
-        expect(tokens[0]).toEqual value: '$$', scopes: ['source.coffee', 'variable.other.object.coffee']
+      {tokens} = grammar.tokenizeLine('$$.prop')
+      expect(tokens[0]).toEqual value: '$$', scopes: ['source.coffee', 'variable.other.object.coffee']
 
-        {tokens} = grammar.tokenizeLine('obj?.prop')
-        expect(tokens[0]).toEqual value: 'obj', scopes: ['source.coffee', 'variable.other.object.coffee']
-        expect(tokens[1]).toEqual value: '?', scopes: ['source.coffee', 'keyword.operator.existential.coffee']
+      {tokens} = grammar.tokenizeLine('obj?.prop')
+      expect(tokens[0]).toEqual value: 'obj', scopes: ['source.coffee', 'variable.other.object.coffee']
+      expect(tokens[1]).toEqual value: '?', scopes: ['source.coffee', 'keyword.operator.existential.coffee']
 
-      it "tokenizes illegal objects", ->
-        {tokens} = grammar.tokenizeLine('1.prop')
-        expect(tokens[0]).toEqual value: '1', scopes: ['source.coffee', 'invalid.illegal.identifier.coffee']
+    it "tokenizes illegal objects", ->
+      {tokens} = grammar.tokenizeLine('1.prop')
+      expect(tokens[0]).toEqual value: '1', scopes: ['source.coffee', 'invalid.illegal.identifier.coffee']
 
-        {tokens} = grammar.tokenizeLine('123.prop')
-        expect(tokens[0]).toEqual value: '123', scopes: ['source.coffee', 'invalid.illegal.identifier.coffee']
+      {tokens} = grammar.tokenizeLine('123.prop')
+      expect(tokens[0]).toEqual value: '123', scopes: ['source.coffee', 'invalid.illegal.identifier.coffee']
 
-        {tokens} = grammar.tokenizeLine('123a.prop')
-        expect(tokens[0]).toEqual value: '123a', scopes: ['source.coffee', 'invalid.illegal.identifier.coffee']
+      {tokens} = grammar.tokenizeLine('123a.prop')
+      expect(tokens[0]).toEqual value: '123a', scopes: ['source.coffee', 'invalid.illegal.identifier.coffee']
+
+  describe "arrays", ->
+    it "tokenizes basic arrays", ->
+      {tokens} = grammar.tokenizeLine('[a, "b", 3]')
+      expect(tokens[0]).toEqual value: '[', scopes: ['source.coffee', 'punctuation.definition.array.begin.bracket.square.coffee']
+      expect(tokens[1]).toEqual value: 'a', scopes: ['source.coffee']
+      expect(tokens[2]).toEqual value: ',', scopes: ['source.coffee', 'punctuation.separator.delimiter.coffee']
+      expect(tokens[3]).toEqual value: ' ', scopes: ['source.coffee']
+      expect(tokens[9]).toEqual value: '3', scopes: ['source.coffee', 'constant.numeric.decimal.coffee']
+      expect(tokens[10]).toEqual value: ']', scopes: ['source.coffee', 'punctuation.definition.array.end.bracket.square.coffee']
+
+    it "tokenizes inclusive and exclusive slices", ->
+      {tokens} = grammar.tokenizeLine('[a..3]')
+      expect(tokens[0]).toEqual value: '[', scopes: ['source.coffee', 'punctuation.definition.array.begin.bracket.square.coffee']
+      expect(tokens[1]).toEqual value: 'a', scopes: ['source.coffee']
+      expect(tokens[2]).toEqual value: '..', scopes: ['source.coffee', 'keyword.operator.slice.inclusive.coffee']
+      expect(tokens[3]).toEqual value: '3', scopes: ['source.coffee', 'constant.numeric.decimal.coffee']
+      expect(tokens[4]).toEqual value: ']', scopes: ['source.coffee', 'punctuation.definition.array.end.bracket.square.coffee']
+
+      {tokens} = grammar.tokenizeLine('[3...b]')
+      expect(tokens[0]).toEqual value: '[', scopes: ['source.coffee', 'punctuation.definition.array.begin.bracket.square.coffee']
+      expect(tokens[1]).toEqual value: '3', scopes: ['source.coffee', 'constant.numeric.decimal.coffee']
+      expect(tokens[2]).toEqual value: '...', scopes: ['source.coffee', 'keyword.operator.slice.exclusive.coffee']
+      expect(tokens[3]).toEqual value: 'b', scopes: ['source.coffee']
+      expect(tokens[4]).toEqual value: ']', scopes: ['source.coffee', 'punctuation.definition.array.end.bracket.square.coffee']
 
   it "verifies that regular expressions have explicit count modifiers", ->
     source = fs.readFileSync(path.resolve(__dirname, '..', 'grammars', 'coffeescript.cson'), 'utf8')
@@ -958,7 +983,7 @@ describe "CoffeeScript grammar", ->
     it "doesn't tokenize nested brackets as destructuring assignments", ->
       {tokens} = grammar.tokenizeLine("[Point(0, 1), [Point(0, 0), Point(0, 1)]]")
       expect(tokens[0]).not.toEqual value: "[", scopes: ["source.coffee", "meta.variable.assignment.destructured.array.coffee", "punctuation.definition.destructuring.begin.bracket.square.coffee"]
-      expect(tokens[0]).toEqual value: "[", scopes: ["source.coffee", "meta.brace.square.coffee"]
+      expect(tokens[0]).toEqual value: "[", scopes: ["source.coffee", "punctuation.definition.array.begin.bracket.square.coffee"]
 
   it "tokenizes inline constant followed by unless statement correctly", ->
     {tokens} = grammar.tokenizeLine("return 0 unless true")
@@ -990,8 +1015,8 @@ describe "CoffeeScript grammar", ->
       expect(tokens[1]).toEqual value: " food ", scopes: ["source.coffee"]
       expect(tokens[2]).toEqual value: "in", scopes: ["source.coffee", "keyword.control.coffee"]
       expect(tokens[3]).toEqual value: " ", scopes: ["source.coffee"]
-      expect(tokens[4]).toEqual value: "[", scopes: ["source.coffee", "meta.brace.square.coffee"]
-      expect(tokens[18]).toEqual value: "]", scopes: ["source.coffee", "meta.brace.square.coffee"]
+      expect(tokens[4]).toEqual value: "[", scopes: ["source.coffee", "punctuation.definition.array.begin.bracket.square.coffee"]
+      expect(tokens[18]).toEqual value: "]", scopes: ["source.coffee", "punctuation.definition.array.end.bracket.square.coffee"]
 
     it "tokenizes loops using the optional `when` keyword", ->
       {tokens} = grammar.tokenizeLine("for food in foods when food isnt chocolate")
@@ -1058,21 +1083,21 @@ describe "CoffeeScript grammar", ->
 
     it "tokenizes regular expressions inside arrays", ->
       {tokens} = grammar.tokenizeLine("[/test/]")
-      expect(tokens[0]).toEqual value: "[", scopes: ["source.coffee", "meta.brace.square.coffee"]
+      expect(tokens[0]).toEqual value: "[", scopes: ["source.coffee", "punctuation.definition.array.begin.bracket.square.coffee"]
       expect(tokens[1]).toEqual value: "/", scopes: ["source.coffee", "string.regexp.coffee", "punctuation.definition.string.begin.coffee"]
       expect(tokens[2]).toEqual value: "test", scopes: ["source.coffee", "string.regexp.coffee"]
       expect(tokens[3]).toEqual value: "/", scopes: ["source.coffee", "string.regexp.coffee", "punctuation.definition.string.end.coffee"]
-      expect(tokens[4]).toEqual value: "]", scopes: ["source.coffee", "meta.brace.square.coffee"]
+      expect(tokens[4]).toEqual value: "]", scopes: ["source.coffee", "punctuation.definition.array.end.bracket.square.coffee"]
 
       {tokens} = grammar.tokenizeLine("[1, /test/]")
-      expect(tokens[0]).toEqual value: "[", scopes: ["source.coffee", "meta.brace.square.coffee"]
+      expect(tokens[0]).toEqual value: "[", scopes: ["source.coffee", "punctuation.definition.array.begin.bracket.square.coffee"]
       expect(tokens[1]).toEqual value: "1", scopes: ["source.coffee", "constant.numeric.decimal.coffee"]
       expect(tokens[2]).toEqual value: ",", scopes: ["source.coffee", "punctuation.separator.delimiter.coffee"]
       expect(tokens[3]).toEqual value: " ", scopes: ["source.coffee"]
       expect(tokens[4]).toEqual value: "/", scopes: ["source.coffee", "string.regexp.coffee", "punctuation.definition.string.begin.coffee"]
       expect(tokens[5]).toEqual value: "test", scopes: ["source.coffee", "string.regexp.coffee"]
       expect(tokens[6]).toEqual value: "/", scopes: ["source.coffee", "string.regexp.coffee", "punctuation.definition.string.end.coffee"]
-      expect(tokens[7]).toEqual value: "]", scopes: ["source.coffee", "meta.brace.square.coffee"]
+      expect(tokens[7]).toEqual value: "]", scopes: ["source.coffee", "punctuation.definition.array.end.bracket.square.coffee"]
 
     it "does not tokenize multiple division as regex", ->
       # https://github.com/atom/language-coffee-script/issues/112


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Adds support for `..` and `...` in arrays.  Leftover from #103.

### Alternate Designs

None.

### Benefits

No weird period highlighting in arrays.

### Possible Drawbacks

This should work smoothly as `[` and `]` are always used to denote arrays.

### Applicable Issues

Fixes #144