### PR TITLE
Block comments are not necessarily multiline

### DIFF
--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -101,10 +101,13 @@
   }
   {
     'begin': '(?<!#)###(?!#)'
-    'captures':
+    'beginCaptures':
       '0':
         'name': 'punctuation.definition.comment.coffee'
-    'end': '###(?:[ \\t]*\\n)'
+    'end': '###'
+    'endCaptures':
+      '0':
+        'name': 'punctuation.definition.comment.coffee'
     'name': 'comment.block.coffee'
     'patterns': [
       {

--- a/spec/coffee-script-spec.coffee
+++ b/spec/coffee-script-spec.coffee
@@ -103,25 +103,25 @@ describe "CoffeeScript grammar", ->
       Until here
       ###
     """
-    expect(lines[1][0]).toEqual value: '###', scopes: ['source.coffee', 'comment.block.coffee', 'punctuation.definition.comment.coffee']
-    expect(lines[1][1]).toEqual value: ' I am a block comment', scopes: ['source.coffee', 'comment.block.coffee']
-    expect(lines[3][0]).toEqual value: 'Until here', scopes: ['source.coffee', 'comment.block.coffee']
-    expect(lines[4][0]).toEqual value: '###', scopes: ['source.coffee', 'comment.block.coffee', 'punctuation.definition.comment.coffee']
+    expect(lines[0][0]).toEqual value: '###', scopes: ['source.coffee', 'comment.block.coffee', 'punctuation.definition.comment.coffee']
+    expect(lines[0][1]).toEqual value: ' I am a block comment', scopes: ['source.coffee', 'comment.block.coffee']
+    expect(lines[2][0]).toEqual value: 'Until here', scopes: ['source.coffee', 'comment.block.coffee']
+    expect(lines[3][0]).toEqual value: '###', scopes: ['source.coffee', 'comment.block.coffee', 'punctuation.definition.comment.coffee']
 
     {tokens} = grammar.tokenizeLine "identity = ###::<T>### (value ###: T ###) ###: T ### ->"
     expect(tokens[0]).toEqual value: 'identity', scopes: ['source.coffee', 'variable.assignment.coffee']
     expect(tokens[4]).toEqual value: '###', scopes: ['source.coffee', 'comment.block.coffee', 'punctuation.definition.comment.coffee']
     expect(tokens[5]).toEqual value: '::<T>', scopes: ['source.coffee', 'comment.block.coffee']
     expect(tokens[6]).toEqual value: '###', scopes: ['source.coffee', 'comment.block.coffee', 'punctuation.definition.comment.coffee']
-    expect(tokens[7]).toEqual value: '  (value ', scopes: ['source.coffee'] # TODO: These scopes are incorrect and should be fixed
-    expect(tokens[8]).toEqual value: '###', scopes: ['source.coffee', 'comment.block.coffee', 'punctuation.definition.comment.coffee']
-    expect(tokens[9]).toEqual value: ': T ', scopes: ['source.coffee', 'comment.block.coffee']
+    expect(tokens[9]).toEqual value: 'value ', scopes: ['source.coffee'] # TODO: These scopes are incorrect and should be fixed
     expect(tokens[10]).toEqual value: '###', scopes: ['source.coffee', 'comment.block.coffee', 'punctuation.definition.comment.coffee']
-    expect(tokens[11]).toEqual value: ') ', scopes: ['source.coffee'] # TODO: These scopes are incorrect and should be fixed
+    expect(tokens[11]).toEqual value: ': T ', scopes: ['source.coffee', 'comment.block.coffee']
     expect(tokens[12]).toEqual value: '###', scopes: ['source.coffee', 'comment.block.coffee', 'punctuation.definition.comment.coffee']
-    expect(tokens[13]).toEqual value: ': T ', scopes: ['source.coffee', 'comment.block.coffee']
-    expect(tokens[14]).toEqual value: '###', scopes: ['source.coffee', 'comment.block.coffee', 'punctuation.definition.comment.coffee']
-    expect(tokens[16]).toEqual value: '->', scopes: ['source.coffee', 'meta.function.inline.coffee', 'storage.type.function.coffee']
+    expect(tokens[14]).toEqual value: ' ', scopes: ['source.coffee'] # TODO: These scopes are incorrect and should be fixed
+    expect(tokens[15]).toEqual value: '###', scopes: ['source.coffee', 'comment.block.coffee', 'punctuation.definition.comment.coffee']
+    expect(tokens[16]).toEqual value: ': T ', scopes: ['source.coffee', 'comment.block.coffee']
+    expect(tokens[17]).toEqual value: '###', scopes: ['source.coffee', 'comment.block.coffee', 'punctuation.definition.comment.coffee']
+    expect(tokens[19]).toEqual value: '->', scopes: ['source.coffee', 'meta.function.inline.coffee', 'storage.type.function.coffee']
 
   it "tokenizes annotations in block comments", ->
     lines = grammar.tokenizeLines """

--- a/spec/coffee-script-spec.coffee
+++ b/spec/coffee-script-spec.coffee
@@ -96,6 +96,33 @@ describe "CoffeeScript grammar", ->
     expect(tokens[0]).toEqual value: "#", scopes: ["source.coffee", "comment.line.number-sign.coffee", "punctuation.definition.comment.coffee"]
     expect(tokens[1]).toEqual value: "{Comment}", scopes: ["source.coffee", "comment.line.number-sign.coffee"]
 
+  it "tokenizes block comments", ->
+    lines = grammar.tokenizeLines """
+      ### I am a block comment
+      Very blocky
+      Until here
+      ###
+    """
+    expect(lines[1][0]).toEqual value: '###', scopes: ['source.coffee', 'comment.block.coffee', 'punctuation.definition.comment.coffee']
+    expect(lines[1][1]).toEqual value: ' I am a block comment', scopes: ['source.coffee', 'comment.block.coffee']
+    expect(lines[3][0]).toEqual value: 'Until here', scopes: ['source.coffee', 'comment.block.coffee']
+    expect(lines[4][0]).toEqual value: '###', scopes: ['source.coffee', 'comment.block.coffee', 'punctuation.definition.comment.coffee']
+
+    {tokens} = grammar.tokenizeLine "identity = ###::<T>### (value ###: T ###) ###: T ### ->"
+    expect(tokens[0]).toEqual value: 'identity', scopes: ['source.coffee', 'variable.assignment.coffee']
+    expect(tokens[4]).toEqual value: '###', scopes: ['source.coffee', 'comment.block.coffee', 'punctuation.definition.comment.coffee']
+    expect(tokens[5]).toEqual value: '::<T>', scopes: ['source.coffee', 'comment.block.coffee']
+    expect(tokens[6]).toEqual value: '###', scopes: ['source.coffee', 'comment.block.coffee', 'punctuation.definition.comment.coffee']
+    expect(tokens[7]).toEqual value: '  (value ', scopes: ['source.coffee'] # TODO: These scopes are incorrect and should be fixed
+    expect(tokens[8]).toEqual value: '###', scopes: ['source.coffee', 'comment.block.coffee', 'punctuation.definition.comment.coffee']
+    expect(tokens[9]).toEqual value: ': T ', scopes: ['source.coffee', 'comment.block.coffee']
+    expect(tokens[10]).toEqual value: '###', scopes: ['source.coffee', 'comment.block.coffee', 'punctuation.definition.comment.coffee']
+    expect(tokens[11]).toEqual value: ') ', scopes: ['source.coffee'] # TODO: These scopes are incorrect and should be fixed
+    expect(tokens[12]).toEqual value: '###', scopes: ['source.coffee', 'comment.block.coffee', 'punctuation.definition.comment.coffee']
+    expect(tokens[13]).toEqual value: ': T ', scopes: ['source.coffee', 'comment.block.coffee']
+    expect(tokens[14]).toEqual value: '###', scopes: ['source.coffee', 'comment.block.coffee', 'punctuation.definition.comment.coffee']
+    expect(tokens[16]).toEqual value: '->', scopes: ['source.coffee', 'meta.function.inline.coffee', 'storage.type.function.coffee']
+
   it "tokenizes annotations in block comments", ->
     lines = grammar.tokenizeLines """
       ###


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

This removes the pattern that was forcing block comments to always be multiline.  However, doing so has exposed more bugs with function tokenization breaking on comments.  I'll see if it can be fixed in this PR.

### Alternate Designs

N/A

### Benefits

Single-line block comments will be tokenized correctly.

### Possible Drawbacks

There are no drawbacks, per say, but as mentioned above this change does reveal some more underlying bugs.

### Applicable Issues

Fixes #149