### PR TITLE
Differentiate between function/method calls with and without parentheses

### DIFF
--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -476,14 +476,24 @@
   'arguments':
     'patterns': [
       {
-        'begin': '(?=(@|@?[\\w$]+|[=-]>|\\-\\d|\\[|{|\"|\'))|\\('
+        'begin': '\\('
         'beginCaptures':
           '0':
             'name': 'punctuation.definition.arguments.begin.bracket.round.coffee'
-        'end': '\\)|(?=\\s*(?<![\\w$])(of|in|then|is|isnt|and|or|for|else|when|if|unless|by|instanceof)(?![\\w$]))|(?=\\s*(}|#|$))'
+        'end': '\\)'
         'endCaptures':
           '0':
             'name': 'punctuation.definition.arguments.end.bracket.round.coffee'
+        'name': 'meta.arguments.coffee'
+        'patterns': [
+          {
+            'include': '$self'
+          }
+        ]
+      }
+      {
+        'begin': '(?=(@|@?[\\w$]+|[=-]>|\\-\\d|\\[|{|\"|\'))'
+        'end': '(?=\\s*(?<![\\w$])(of|in|then|is|isnt|and|or|for|else|when|if|unless|by|instanceof)(?![\\w$]))|(?=\\s*(}|\\)|#|$))'
         'name': 'meta.arguments.coffee'
         'patterns': [
           {
@@ -522,10 +532,30 @@
     'patterns': [
       {
         # functionCall(arg1, "arg2", [...])
+        'begin': '(@)?([\\w$]+)(?=\\()'
+        'beginCaptures':
+          '1':
+            'name': 'variable.other.readwrite.instance.coffee'
+          '2':
+            'patterns': [
+              {
+                'include': '#function_names'
+              }
+            ]
+        'end': '(?<=\\))'
+        'name': 'meta.function-call.coffee'
+        'patterns': [
+          {
+            'include': '#arguments'
+          }
+        ]
+      }
+      {
+        # functionCall arg1, "arg2", [...]
         'begin': '''(?x)
           (@)?([\\w$]+)
           \\s*
-          (?=\\s+(?!(?<![\\w$])(of|in|then|is|isnt|and|or|for|else|when|if|unless|by|instanceof)(?![\\w$]))(?=(@?[\\w$]+|[=-]>|\\-\\d|\\[|\\{|\"|\'))|(?=\\())
+          (?=\\s+(?!(?<![\\w$])(of|in|then|is|isnt|and|or|for|else|when|if|unless|by|instanceof)(?![\\w$]))(?=(@?[\\w$]+|[=-]>|\\-\\d|\\[|{|\"|\')))
         '''
         'beginCaptures':
           '1':
@@ -533,29 +563,35 @@
           '2':
             'patterns': [
               {
-                'match': '''(?x)
-                  \\b(isNaN|isFinite|eval|uneval|parseInt|parseFloat|decodeURI|
-                  decodeURIComponent|encodeURI|encodeURIComponent|escape|unescape|
-                  require|set(Interval|Timeout)|clear(Interval|Timeout))\\b
-                '''
-                'name': 'support.function.coffee'
-              }
-              {
-                'match': "[a-zA-Z_$][\\w$]*"
-                'name': 'entity.name.function.coffee'
-              }
-              {
-                'match': '\\d[\\w$]*'
-                'name': 'invalid.illegal.identifier.coffee'
+                'include': '#function_names'
               }
             ]
-        'end': '(?<=\\))|(?=\\s*(?<![\\w$])(of|in|then|is|isnt|and|or|for|else|when|if|unless|by|instanceof)(?![\\w$]))|(?=\\s*(}|#|$))'
+        'end': '(?=\\s*(?<![\\w$])(of|in|then|is|isnt|and|or|for|else|when|if|unless|by|instanceof)(?![\\w$]))|(?=\\s*(}|\\)|#|$))'
         'name': 'meta.function-call.coffee'
         'patterns': [
           {
             'include': '#arguments'
           }
         ]
+      }
+    ]
+  'function_names':
+    'patterns': [
+      {
+        'match': '''(?x)
+          \\b(isNaN|isFinite|eval|uneval|parseInt|parseFloat|decodeURI|
+          decodeURIComponent|encodeURI|encodeURIComponent|escape|unescape|
+          require|set(Interval|Timeout)|clear(Interval|Timeout))\\b
+        '''
+        'name': 'support.function.coffee'
+      }
+      {
+        'match': "[a-zA-Z_$][\\w$]*"
+        'name': 'entity.name.function.coffee'
+      }
+      {
+        'match': '\\d[\\w$]*'
+        'name': 'invalid.illegal.identifier.coffee'
       }
     ]
   'function_params':
@@ -630,7 +666,7 @@
     'patterns': [
       {
         # .methodCall(arg1, "arg2", [...])
-        'begin': '(?:(\\.)|(::))\\s*([\\w$]+)\\s*(?=\\s+(?!(?<![\\w$])(of|in|then|is|isnt|and|or|for|else|when|if|unless|by|instanceof)(?![\\w$]))(?=(@|@?[\\w$]+|[=-]>|\\-\\d|\\[|\\{|\"|\'))|(?=\\())'
+        'begin': '(?:(\\.)|(::))\\s*([\\w$]+)\\s*(?=\\()'
         'beginCaptures':
           '1':
             'name': 'punctuation.separator.method.period.coffee'
@@ -639,105 +675,133 @@
           '3':
             'patterns': [
               {
-                'match': '''(?x)
-                  \\bon(Rowsinserted|Rowsdelete|Rowenter|Rowexit|Resize|Resizestart|Resizeend|Reset|
-                  Readystatechange|Mouseout|Mouseover|Mousedown|Mouseup|Mousemove|
-                  Before(cut|deactivate|unload|update|paste|print|editfocus|activate)|
-                  Blur|Scrolltop|Submit|Select|Selectstart|Selectionchange|Hover|Help|
-                  Change|Contextmenu|Controlselect|Cut|Cellchange|Clock|Close|Deactivate|
-                  Datasetchanged|Datasetcomplete|Dataavailable|Drop|Drag|Dragstart|Dragover|
-                  Dragdrop|Dragenter|Dragend|Dragleave|Dblclick|Unload|Paste|Propertychange|Error|
-                  Errorupdate|Keydown|Keyup|Keypress|Focus|Load|Activate|Afterupdate|Afterprint|Abort)\\b
-                '''
-                'name': 'support.function.event-handler.coffee'
-              }
-              {
-                'match': '''(?x)
-                  \\b(shift|showModelessDialog|showModalDialog|showHelp|scroll|scrollX|scrollByPages|
-                  scrollByLines|scrollY|scrollTo|stop|strike|sizeToContent|sidebar|signText|sort|
-                  sup|sub|substr|substring|splice|split|send|set(Milliseconds|Seconds|Minutes|Hours|
-                  Month|Year|FullYear|Date|UTC(Milliseconds|Seconds|Minutes|Hours|Month|FullYear|Date)|
-                  Time|Hotkeys|Cursor|ZOptions|Active|Resizable|RequestHeader)|search|slice|
-                  savePreferences|small|home|handleEvent|navigate|char|charCodeAt|charAt|concat|
-                  contextual|confirm|compile|clear|captureEvents|call|createStyleSheet|createPopup|
-                  createEventObject|to(GMTString|UTCString|String|Source|UpperCase|LowerCase|LocaleString)|
-                  test|taint|taintEnabled|indexOf|italics|disableExternalCapture|dump|detachEvent|unshift|
-                  untaint|unwatch|updateCommands|join|javaEnabled|pop|push|plugins.refresh|paddings|parse|
-                  print|prompt|preference|enableExternalCapture|exec|execScript|valueOf|UTC|find|file|
-                  fileModifiedDate|fileSize|fileCreatedDate|fileUpdatedDate|fixed|fontsize|fontcolor|
-                  forward|fromCharCode|watch|link|load|lastIndexOf|anchor|attachEvent|atob|apply|alert|
-                  abort|routeEvents|resize|resizeBy|resizeTo|recalc|returnValue|replace|reverse|reload|
-                  releaseCapture|releaseEvents|go|get(Milliseconds|Seconds|Minutes|Hours|Month|Day|Year|FullYear|
-                  Time|Date|TimezoneOffset|UTC(Milliseconds|Seconds|Minutes|Hours|Day|Month|FullYear|Date)|
-                  Attention|Selection|ResponseHeader|AllResponseHeaders)|moveBy|moveBelow|moveTo|
-                  moveToAbsolute|moveAbove|mergeAttributes|match|margins|btoa|big|bold|borderWidths|blink|back)\\b
-                '''
-                'name': 'support.function.coffee'
-              }
-              {
-                'match': '''(?x)
-                  \\b(acceptNode|add|addEventListener|addTextTrack|adoptNode|after|animate|append|
-                  appendChild|appendData|before|blur|canPlayType|captureStream|
-                  caretPositionFromPoint|caretRangeFromPoint|checkValidity|clear|click|
-                  cloneContents|cloneNode|cloneRange|close|closest|collapse|
-                  compareBoundaryPoints|compareDocumentPosition|comparePoint|contains|
-                  convertPointFromNode|convertQuadFromNode|convertRectFromNode|createAttribute|
-                  createAttributeNS|createCaption|createCDATASection|createComment|
-                  createContextualFragment|createDocument|createDocumentFragment|
-                  createDocumentType|createElement|createElementNS|createEntityReference|
-                  createEvent|createExpression|createHTMLDocument|createNodeIterator|
-                  createNSResolver|createProcessingInstruction|createRange|createShadowRoot|
-                  createTBody|createTextNode|createTFoot|createTHead|createTreeWalker|delete|
-                  deleteCaption|deleteCell|deleteContents|deleteData|deleteRow|deleteTFoot|
-                  deleteTHead|detach|disconnect|dispatchEvent|elementFromPoint|elementsFromPoint|
-                  enableStyleSheetsForSet|entries|evaluate|execCommand|exitFullscreen|
-                  exitPointerLock|expand|extractContents|fastSeek|firstChild|focus|forEach|get|
-                  getAll|getAnimations|getAttribute|getAttributeNames|getAttributeNode|
-                  getAttributeNodeNS|getAttributeNS|getBoundingClientRect|getBoxQuads|
-                  getClientRects|getContext|getDestinationInsertionPoints|getElementById|
-                  getElementsByClassName|getElementsByName|getElementsByTagName|
-                  getElementsByTagNameNS|getItem|getNamedItem|getSelection|getStartDate|
-                  getVideoPlaybackQuality|has|hasAttribute|hasAttributeNS|hasAttributes|
-                  hasChildNodes|hasFeature|hasFocus|importNode|initEvent|insertAdjacentElement|
-                  insertAdjacentHTML|insertAdjacentText|insertBefore|insertCell|insertData|
-                  insertNode|insertRow|intersectsNode|isDefaultNamespace|isEqualNode|
-                  isPointInRange|isSameNode|item|key|keys|lastChild|load|lookupNamespaceURI|
-                  lookupPrefix|matches|move|moveAttribute|moveAttributeNode|moveChild|
-                  moveNamedItem|namedItem|nextNode|nextSibling|normalize|observe|open|
-                  parentNode|pause|play|postMessage|prepend|preventDefault|previousNode|
-                  previousSibling|probablySupportsContext|queryCommandEnabled|
-                  queryCommandIndeterm|queryCommandState|queryCommandSupported|queryCommandValue|
-                  querySelector|querySelectorAll|registerContentHandler|registerElement|
-                  registerProtocolHandler|releaseCapture|releaseEvents|remove|removeAttribute|
-                  removeAttributeNode|removeAttributeNS|removeChild|removeEventListener|
-                  removeItem|replace|replaceChild|replaceData|replaceWith|reportValidity|
-                  requestFullscreen|requestPointerLock|reset|scroll|scrollBy|scrollIntoView|
-                  scrollTo|seekToNextFrame|select|selectNode|selectNodeContents|set|setAttribute|
-                  setAttributeNode|setAttributeNodeNS|setAttributeNS|setCapture|
-                  setCustomValidity|setEnd|setEndAfter|setEndBefore|setItem|setNamedItem|
-                  setRangeText|setSelectionRange|setSinkId|setStart|setStartAfter|setStartBefore|
-                  slice|splitText|stepDown|stepUp|stopImmediatePropagation|stopPropagation|
-                  submit|substringData|supports|surroundContents|takeRecords|terminate|toBlob|
-                  toDataURL|toggle|toString|values|write|writeln)\\b
-                '''
-                'name': 'support.function.dom.coffee'
-              }
-              {
-                'match': "[a-zA-Z_$][\\w$]*"
-                'name': 'entity.name.function.coffee'
-              }
-              {
-                'match': '\\d[\\w$]*'
-                'name': 'invalid.illegal.identifier.coffee'
+                'include': '#method_names'
               }
             ]
-        'end': '(?<=\\))|(?=\\s*(?<![\\w$])(of|in|then|is|isnt|and|or|for|else|when|if|unless|by|instanceof)(?![\\w$]))|(?=\\s*(}|#|$))'
+        'end': '(?<=\\))'
         'name': 'meta.method-call.coffee'
         'patterns': [
           {
             'include': '#arguments'
           }
         ]
+      }
+      {
+        # .methodCall arg1, "arg2", [...]
+        'begin': '(?:(\\.)|(::))\\s*([\\w$]+)\\s*(?=\\s+(?!(?<![\\w$])(of|in|then|is|isnt|and|or|for|else|when|if|unless|by|instanceof)(?![\\w$]))(?=(@|@?[\\w$]+|[=-]>|\\-\\d|\\[|{|\"|\')))'
+        'beginCaptures':
+          '1':
+            'name': 'punctuation.separator.method.period.coffee'
+          '2':
+            'name': 'keyword.operator.prototype.coffee'
+          '3':
+            'patterns': [
+              {
+                'include': '#method_names'
+              }
+            ]
+        'end': '(?=\\s*(?<![\\w$])(of|in|then|is|isnt|and|or|for|else|when|if|unless|by|instanceof)(?![\\w$]))|(?=\\s*(}|\\)|#|$))'
+        'name': 'meta.method-call.coffee'
+        'patterns': [
+          {
+            'include': '#arguments'
+          }
+        ]
+      }
+    ]
+  'method_names':
+    'patterns': [
+      {
+        'match': '''(?x)
+          \\bon(Rowsinserted|Rowsdelete|Rowenter|Rowexit|Resize|Resizestart|Resizeend|Reset|
+          Readystatechange|Mouseout|Mouseover|Mousedown|Mouseup|Mousemove|
+          Before(cut|deactivate|unload|update|paste|print|editfocus|activate)|
+          Blur|Scrolltop|Submit|Select|Selectstart|Selectionchange|Hover|Help|
+          Change|Contextmenu|Controlselect|Cut|Cellchange|Clock|Close|Deactivate|
+          Datasetchanged|Datasetcomplete|Dataavailable|Drop|Drag|Dragstart|Dragover|
+          Dragdrop|Dragenter|Dragend|Dragleave|Dblclick|Unload|Paste|Propertychange|Error|
+          Errorupdate|Keydown|Keyup|Keypress|Focus|Load|Activate|Afterupdate|Afterprint|Abort)\\b
+        '''
+        'name': 'support.function.event-handler.coffee'
+      }
+      {
+        'match': '''(?x)
+          \\b(shift|showModelessDialog|showModalDialog|showHelp|scroll|scrollX|scrollByPages|
+          scrollByLines|scrollY|scrollTo|stop|strike|sizeToContent|sidebar|signText|sort|
+          sup|sub|substr|substring|splice|split|send|set(Milliseconds|Seconds|Minutes|Hours|
+          Month|Year|FullYear|Date|UTC(Milliseconds|Seconds|Minutes|Hours|Month|FullYear|Date)|
+          Time|Hotkeys|Cursor|ZOptions|Active|Resizable|RequestHeader)|search|slice|
+          savePreferences|small|home|handleEvent|navigate|char|charCodeAt|charAt|concat|
+          contextual|confirm|compile|clear|captureEvents|call|createStyleSheet|createPopup|
+          createEventObject|to(GMTString|UTCString|String|Source|UpperCase|LowerCase|LocaleString)|
+          test|taint|taintEnabled|indexOf|italics|disableExternalCapture|dump|detachEvent|unshift|
+          untaint|unwatch|updateCommands|join|javaEnabled|pop|push|plugins.refresh|paddings|parse|
+          print|prompt|preference|enableExternalCapture|exec|execScript|valueOf|UTC|find|file|
+          fileModifiedDate|fileSize|fileCreatedDate|fileUpdatedDate|fixed|fontsize|fontcolor|
+          forward|fromCharCode|watch|link|load|lastIndexOf|anchor|attachEvent|atob|apply|alert|
+          abort|routeEvents|resize|resizeBy|resizeTo|recalc|returnValue|replace|reverse|reload|
+          releaseCapture|releaseEvents|go|get(Milliseconds|Seconds|Minutes|Hours|Month|Day|Year|FullYear|
+          Time|Date|TimezoneOffset|UTC(Milliseconds|Seconds|Minutes|Hours|Day|Month|FullYear|Date)|
+          Attention|Selection|ResponseHeader|AllResponseHeaders)|moveBy|moveBelow|moveTo|
+          moveToAbsolute|moveAbove|mergeAttributes|match|margins|btoa|big|bold|borderWidths|blink|back)\\b
+        '''
+        'name': 'support.function.coffee'
+      }
+      {
+        'match': '''(?x)
+          \\b(acceptNode|add|addEventListener|addTextTrack|adoptNode|after|animate|append|
+          appendChild|appendData|before|blur|canPlayType|captureStream|
+          caretPositionFromPoint|caretRangeFromPoint|checkValidity|clear|click|
+          cloneContents|cloneNode|cloneRange|close|closest|collapse|
+          compareBoundaryPoints|compareDocumentPosition|comparePoint|contains|
+          convertPointFromNode|convertQuadFromNode|convertRectFromNode|createAttribute|
+          createAttributeNS|createCaption|createCDATASection|createComment|
+          createContextualFragment|createDocument|createDocumentFragment|
+          createDocumentType|createElement|createElementNS|createEntityReference|
+          createEvent|createExpression|createHTMLDocument|createNodeIterator|
+          createNSResolver|createProcessingInstruction|createRange|createShadowRoot|
+          createTBody|createTextNode|createTFoot|createTHead|createTreeWalker|delete|
+          deleteCaption|deleteCell|deleteContents|deleteData|deleteRow|deleteTFoot|
+          deleteTHead|detach|disconnect|dispatchEvent|elementFromPoint|elementsFromPoint|
+          enableStyleSheetsForSet|entries|evaluate|execCommand|exitFullscreen|
+          exitPointerLock|expand|extractContents|fastSeek|firstChild|focus|forEach|get|
+          getAll|getAnimations|getAttribute|getAttributeNames|getAttributeNode|
+          getAttributeNodeNS|getAttributeNS|getBoundingClientRect|getBoxQuads|
+          getClientRects|getContext|getDestinationInsertionPoints|getElementById|
+          getElementsByClassName|getElementsByName|getElementsByTagName|
+          getElementsByTagNameNS|getItem|getNamedItem|getSelection|getStartDate|
+          getVideoPlaybackQuality|has|hasAttribute|hasAttributeNS|hasAttributes|
+          hasChildNodes|hasFeature|hasFocus|importNode|initEvent|insertAdjacentElement|
+          insertAdjacentHTML|insertAdjacentText|insertBefore|insertCell|insertData|
+          insertNode|insertRow|intersectsNode|isDefaultNamespace|isEqualNode|
+          isPointInRange|isSameNode|item|key|keys|lastChild|load|lookupNamespaceURI|
+          lookupPrefix|matches|move|moveAttribute|moveAttributeNode|moveChild|
+          moveNamedItem|namedItem|nextNode|nextSibling|normalize|observe|open|
+          parentNode|pause|play|postMessage|prepend|preventDefault|previousNode|
+          previousSibling|probablySupportsContext|queryCommandEnabled|
+          queryCommandIndeterm|queryCommandState|queryCommandSupported|queryCommandValue|
+          querySelector|querySelectorAll|registerContentHandler|registerElement|
+          registerProtocolHandler|releaseCapture|releaseEvents|remove|removeAttribute|
+          removeAttributeNode|removeAttributeNS|removeChild|removeEventListener|
+          removeItem|replace|replaceChild|replaceData|replaceWith|reportValidity|
+          requestFullscreen|requestPointerLock|reset|scroll|scrollBy|scrollIntoView|
+          scrollTo|seekToNextFrame|select|selectNode|selectNodeContents|set|setAttribute|
+          setAttributeNode|setAttributeNodeNS|setAttributeNS|setCapture|
+          setCustomValidity|setEnd|setEndAfter|setEndBefore|setItem|setNamedItem|
+          setRangeText|setSelectionRange|setSinkId|setStart|setStartAfter|setStartBefore|
+          slice|splitText|stepDown|stepUp|stopImmediatePropagation|stopPropagation|
+          submit|substringData|supports|surroundContents|takeRecords|terminate|toBlob|
+          toDataURL|toggle|toString|values|write|writeln)\\b
+        '''
+        'name': 'support.function.dom.coffee'
+      }
+      {
+        'match': "[a-zA-Z_$][\\w$]*"
+        'name': 'entity.name.function.coffee'
+      }
+      {
+        'match': '\\d[\\w$]*'
+        'name': 'invalid.illegal.identifier.coffee'
       }
     ]
   'numbers':

--- a/spec/coffee-script-spec.coffee
+++ b/spec/coffee-script-spec.coffee
@@ -679,6 +679,17 @@ describe "CoffeeScript grammar", ->
       expect(tokens[6]).toEqual value: "in", scopes: ["source.coffee", "keyword.control.coffee"]
       expect(tokens[7]).toEqual value: " foods", scopes: ["source.coffee"]
 
+      {tokens} = grammar.tokenizeLine("(eat food for food in get foods)")
+      expect(tokens[0]).toEqual value: "(", scopes: ["source.coffee", "meta.brace.round.coffee"]
+      expect(tokens[1]).toEqual value: "eat", scopes: ["source.coffee", "meta.function-call.coffee", "entity.name.function.coffee"]
+      expect(tokens[3]).toEqual value: "food", scopes: ["source.coffee", "meta.function-call.coffee", "meta.arguments.coffee"]
+      expect(tokens[5]).toEqual value: "for", scopes: ["source.coffee", "keyword.control.coffee"]
+      expect(tokens[6]).toEqual value: " food ", scopes: ["source.coffee"]
+      expect(tokens[7]).toEqual value: "in", scopes: ["source.coffee", "keyword.control.coffee"]
+      expect(tokens[9]).toEqual value: "get", scopes: ["source.coffee", "meta.function-call.coffee", "entity.name.function.coffee"]
+      expect(tokens[11]).toEqual value: "foods", scopes: ["source.coffee", "meta.function-call.coffee", "meta.arguments.coffee"]
+      expect(tokens[12]).toEqual value: ")", scopes: ["source.coffee", "meta.brace.round.coffee"]
+
       {tokens} = grammar.tokenizeLine("foo @bar")
       expect(tokens[0]).toEqual value: "foo", scopes: ["source.coffee", "meta.function-call.coffee", "entity.name.function.coffee"]
       expect(tokens[2]).toEqual value: "@bar", scopes: ["source.coffee", "meta.function-call.coffee", "meta.arguments.coffee", "variable.other.readwrite.instance.coffee"]
@@ -932,6 +943,15 @@ describe "CoffeeScript grammar", ->
       expect(tokens[2]).toEqual value: 'b', scopes: ['source.coffee', 'meta.method-call.coffee', 'entity.name.function.coffee']
       expect(tokens[3]).toEqual value: ' ', scopes: ['source.coffee', 'meta.method-call.coffee']
       expect(tokens[4]).toEqual value: 'c', scopes: ['source.coffee', 'meta.method-call.coffee', 'meta.arguments.coffee']
+
+      {tokens} = grammar.tokenizeLine('(a.b c)')
+      expect(tokens[0]).toEqual value: '(', scopes: ['source.coffee', 'meta.brace.round.coffee']
+      expect(tokens[1]).toEqual value: 'a', scopes: ['source.coffee', 'variable.other.object.coffee']
+      expect(tokens[2]).toEqual value: '.', scopes: ['source.coffee', 'meta.method-call.coffee', 'punctuation.separator.method.period.coffee']
+      expect(tokens[3]).toEqual value: 'b', scopes: ['source.coffee', 'meta.method-call.coffee', 'entity.name.function.coffee']
+      expect(tokens[4]).toEqual value: ' ', scopes: ['source.coffee', 'meta.method-call.coffee']
+      expect(tokens[5]).toEqual value: 'c', scopes: ['source.coffee', 'meta.method-call.coffee', 'meta.arguments.coffee']
+      expect(tokens[6]).toEqual value: ')', scopes: ['source.coffee', 'meta.brace.round.coffee']
 
       {tokens} = grammar.tokenizeLine('a.b not c')
       expect(tokens[0]).toEqual value: 'a', scopes: ['source.coffee', 'variable.other.object.coffee']


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

Separate function/method call matching into two categories: calls with parentheses and calls without.  This prevents the grammar from starting an argument list without parentheses but then ending it _with_ a parenthesis.  This can happen, for example, when the function call is wrapped in parentheses like so: `(eat food)`.

### Alternate Designs

None.

### Benefits

Argument list tokenization is now consistent: no more potential for mixed parentheses matching.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #153
Fixes #154
Fixes #155

/cc @nathancarter: Thanks so much for the detailed issues that you created.  They really helped me track down the cause of the issue, even if they weren't directly litcoffee-related.  You were right that they have the same root cause :).