### PR TITLE
Add proper boundary-checking for and=, or=

### DIFF
--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -801,7 +801,15 @@
   'operators':
     'patterns': [
       {
-        'match': '([a-zA-Z$_][\\w$]*)?\\s*(%=|\\+=|-=|\\*=|and=|or=|&&=|\\|\\|=|\\?=|(?<!\\()/=)'
+        'match': '(?:([a-zA-Z$_][\\w$]*)?\\s+|(?<![\\w$]))(and=|or=)'
+        'captures':
+          '1':
+            'name': 'variable.assignment.coffee'
+          '2':
+            'name': 'keyword.operator.assignment.compound.coffee'
+      }
+      {
+        'match': '([a-zA-Z$_][\\w$]*)?\\s*(%=|\\+=|-=|\\*=|&&=|\\|\\|=|\\?=|(?<!\\()/=)'
         'captures':
           '1':
             'name': 'variable.assignment.coffee'

--- a/spec/coffee-script-spec.coffee
+++ b/spec/coffee-script-spec.coffee
@@ -214,10 +214,20 @@ describe "CoffeeScript grammar", ->
     expect(tokens[2]).toEqual value: "and=", scopes: ["source.coffee", "keyword.operator.assignment.compound.coffee"]
     expect(tokens[3]).toEqual value: " b", scopes: ["source.coffee"]
 
+    # Should NOT be tokenized as and=
+    {tokens} = grammar.tokenizeLine("operand=true")
+    expect(tokens[0]).toEqual value: "operand", scopes: ["source.coffee", "variable.assignment.coffee"]
+    expect(tokens[1]).toEqual value: "=", scopes: ["source.coffee", "keyword.operator.assignment.coffee"]
+
     {tokens} = grammar.tokenizeLine("a or= b")
     expect(tokens[0]).toEqual value: "a", scopes: ["source.coffee", "variable.assignment.coffee"]
     expect(tokens[2]).toEqual value: "or=", scopes: ["source.coffee", "keyword.operator.assignment.compound.coffee"]
     expect(tokens[3]).toEqual value: " b", scopes: ["source.coffee"]
+
+    # Should NOT be tokenized as or=
+    {tokens} = grammar.tokenizeLine("editor=false")
+    expect(tokens[0]).toEqual value: "editor", scopes: ["source.coffee", "variable.assignment.coffee"]
+    expect(tokens[1]).toEqual value: "=", scopes: ["source.coffee", "keyword.operator.assignment.coffee"]
 
     {tokens} = grammar.tokenizeLine("a -= b")
     expect(tokens[0]).toEqual value: "a", scopes: ["source.coffee", "variable.assignment.coffee"]


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

`and=` and `or=` were being lumped with the other compound assignment operators, which since they're symbols do not require any whitespace around the operator.  `and=` and `or=` however do require whitespace since they're English.  Therefore, extract those two into their own pattern with proper boundary checking (identifier + spaces, or no identifier before the operator).

### Alternate Designs

None.

### Benefits

`operand=`, `editor=` will be tokenized correctly.

### Possible Drawbacks

None.

### Applicable Issues

Fixes #152