### PR TITLE
Add scope to identify single-quoted heredocs

### DIFF
--- a/.coffeelintignore
+++ b/.coffeelintignore
@@ -1,1 +1,0 @@
-spec/fixtures

--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -127,7 +127,7 @@
   {
     'begin': '///'
     'end': '(///)[gimuy]*'
-    'name': 'string.regexp.coffee'
+    'name': 'string.regexp.multiline.coffee'
     'beginCaptures':
       '0':
         'name': 'punctuation.definition.string.begin.coffee'

--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -49,7 +49,7 @@
     'endCaptures':
       '0':
         'name': 'punctuation.definition.string.end.coffee'
-    'name': 'string.quoted.heredoc.coffee'
+    'name': 'string.quoted.single.heredoc.coffee'
     'patterns': [
       {
         'captures':

--- a/spec/coffee-script-spec.coffee
+++ b/spec/coffee-script-spec.coffee
@@ -1194,6 +1194,60 @@ describe "CoffeeScript grammar", ->
       expect(tokens[7]).toEqual value: "/", scopes: ["source.coffee", "meta.method-call.coffee", "meta.arguments.coffee", "string.regexp.coffee", "punctuation.definition.string.end.coffee"]
       expect(tokens[12]).toEqual value: "/", scopes: ["source.coffee", "meta.method-call.coffee", "meta.arguments.coffee", "string.quoted.single.coffee"]
 
+    it "tokenises multi-line regular expressions", ->
+      {tokens} = grammar.tokenizeLine('/// (XYZ) ///')
+      expect(tokens[0]).toEqual value: '///', scopes: ['source.coffee', 'string.regexp.multiline.coffee', 'punctuation.definition.string.begin.coffee']
+      expect(tokens[2]).toEqual value: '(', scopes: ['source.coffee', 'string.regexp.multiline.coffee', 'meta.group.regexp', 'punctuation.definition.group.regexp']
+      expect(tokens[3]).toEqual value: 'XYZ', scopes: ['source.coffee', 'string.regexp.multiline.coffee', 'meta.group.regexp']
+      expect(tokens[4]).toEqual value: ')', scopes: ['source.coffee', 'string.regexp.multiline.coffee', 'meta.group.regexp', 'punctuation.definition.group.regexp']
+      expect(tokens[6]).toEqual value: '///', scopes: ['source.coffee', 'string.regexp.multiline.coffee', 'punctuation.definition.string.end.coffee']
+
+      lines = grammar.tokenizeLines """
+        ///
+        XYZ //
+        /~/
+        ///
+      """
+      expect(lines[0][0]).toEqual value: '///', scopes: ['source.coffee', 'string.regexp.multiline.coffee', 'punctuation.definition.string.begin.coffee']
+      expect(lines[1][0]).toEqual value: 'XYZ //', scopes: ['source.coffee', 'string.regexp.multiline.coffee']
+      expect(lines[2][0]).toEqual value: '/~/', scopes: ['source.coffee', 'string.regexp.multiline.coffee']
+      expect(lines[3][0]).toEqual value: '///', scopes: ['source.coffee', 'string.regexp.multiline.coffee', 'punctuation.definition.string.end.coffee']
+
+  describe "here-docs", ->
+    it "tokenises single-quoted here-docs", ->
+      {tokens} = grammar.tokenizeLine "'''XYZ'''"
+      expect(tokens[0]).toEqual value: "'''", scopes: ['source.coffee', 'string.quoted.single.heredoc.coffee', 'punctuation.definition.string.begin.coffee']
+      expect(tokens[1]).toEqual value: 'XYZ', scopes: ['source.coffee', 'string.quoted.single.heredoc.coffee']
+      expect(tokens[2]).toEqual value: "'''", scopes: ['source.coffee', 'string.quoted.single.heredoc.coffee', 'punctuation.definition.string.end.coffee']
+
+      lines = grammar.tokenizeLines """
+        '''
+        'ABC'
+        XYZ ''
+        '''
+      """
+      expect(lines[0][0]).toEqual value: "'''", scopes: ['source.coffee', 'string.quoted.single.heredoc.coffee', 'punctuation.definition.string.begin.coffee']
+      expect(lines[1][0]).toEqual value: "'ABC'", scopes: ['source.coffee', 'string.quoted.single.heredoc.coffee']
+      expect(lines[2][0]).toEqual value: "XYZ ''", scopes: ['source.coffee', 'string.quoted.single.heredoc.coffee']
+      expect(lines[3][0]).toEqual value: "'''", scopes: ['source.coffee', 'string.quoted.single.heredoc.coffee', 'punctuation.definition.string.end.coffee']
+
+    it "tokenises double-quoted here-docs", ->
+      {tokens} = grammar.tokenizeLine "'''XYZ'''"
+      expect(tokens[0]).toEqual value: "'''", scopes: ['source.coffee', 'string.quoted.single.heredoc.coffee', 'punctuation.definition.string.begin.coffee']
+      expect(tokens[1]).toEqual value: 'XYZ', scopes: ['source.coffee', 'string.quoted.single.heredoc.coffee']
+      expect(tokens[2]).toEqual value: "'''", scopes: ['source.coffee', 'string.quoted.single.heredoc.coffee', 'punctuation.definition.string.end.coffee']
+
+      lines = grammar.tokenizeLines '''
+        """
+        "ABC"
+        XYZ ""
+        """
+      '''
+      expect(lines[0][0]).toEqual value: '"""', scopes: ['source.coffee', 'string.quoted.double.heredoc.coffee', 'punctuation.definition.string.begin.coffee']
+      expect(lines[1][0]).toEqual value: '"ABC"', scopes: ['source.coffee', 'string.quoted.double.heredoc.coffee']
+      expect(lines[2][0]).toEqual value: 'XYZ ""', scopes: ['source.coffee', 'string.quoted.double.heredoc.coffee']
+      expect(lines[3][0]).toEqual value: '"""', scopes: ['source.coffee', 'string.quoted.double.heredoc.coffee', 'punctuation.definition.string.end.coffee']
+
   describe "escape sequences in strings", ->
     it "tokenises leading backslashes in double-quoted strings", ->
       {tokens} = grammar.tokenizeLine('"a\\\\b\\\\\\\\c"')


### PR DESCRIPTION
### Description of the Change

Just a simple, tiny fix: double-quoted heredocs are scoped with `string.quoted.double.heredoc`, but there's nothing to identify heredocs which are delimited by three apostrophes:

~~~cson
string: '''
	Heredoc
'''
~~~

**UPDATE:**  
I've added a scope to identify multiline regular expressions, too:

~~~cson
regexp: ///
	(Stuff | etc)
///
~~~

### Benefits

Easier targeting with stylesheets. If a user wishes to style only single-quoted heredocs, they need to resort to duplicated rulesets, or sticking `:not(.double)` in the selector.
