### PR TITLE
add 'numeric' class to negative sign

### DIFF
--- a/grammars/coffeescript.cson
+++ b/grammars/coffeescript.cson
@@ -929,6 +929,10 @@
         'name': 'keyword.operator.existential.coffee'
       }
       {
+        'match': '-(?=\\.?[0-9])'
+        'name': 'keyword.operator.numeric.coffee'
+      }
+      {
         'match': '%|\\*|/|-|\\+'
         'name': 'keyword.operator.coffee'
       }


### PR DESCRIPTION
Adding `numeric` to the negative sign (eg: `-2`) is great if you want the symbol to have the same color as numbers.

Subtraction is not affected.