### PR TITLE
🤖 Configure probot/no-response to allow 28 days when requesting more info on an issue

### DIFF
--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,7 +1,7 @@
 # Configuration for probot-no-response - https://github.com/probot/no-response
 
 # Number of days of inactivity before an issue is closed for lack of response
-daysUntilClose: 180
+daysUntilClose: 28
 
 # Label requiring a response
 responseRequiredLabel: more-information-needed


### PR DESCRIPTION
### Description of the Change

Please see https://github.com/atom/atom/pull/18139

### Benefits

Please see https://github.com/atom/atom/pull/18139

### Possible Drawbacks

Please see https://github.com/atom/atom/pull/18139